### PR TITLE
feat:  Improve find_related API, fix chunk boundary bug, update MCP instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ result.chunk.start_line  # 127
 result.chunk.end_line    # 150
 result.chunk.content     # "def save_pretrained(self, path: PathLike, ..."
 
-# Find code similar to a specific location in the codebase
-related = index.find_related("model2vec/model.py", line=127, top_k=3)
+# Find code similar to a specific result
+related = index.find_related(results[0], top_k=3)
 ```
 
 ## Main Features

--- a/src/semble/index/index.py
+++ b/src/semble/index/index.py
@@ -181,18 +181,16 @@ class SembleIndex:
         else:
             if line is None:
                 raise TypeError("line is required when source is a file path string")
-            # Single pass: prefer exclusive end boundary to resolve ambiguity when adjacent
-            # chunks share a boundary line (e.g. chunk A ends at 127, chunk B starts at 127).
-            # Keep the first inclusive-only match as fallback for end-of-file chunks.
+            # Prefer exclusive end to avoid shared-boundary ambiguity; fall back to inclusive.
             target = None
             fallback: Chunk | None = None
-            for c in self.chunks:
-                if c.file_path == source and c.start_line <= line <= c.end_line:
-                    if line < c.end_line:
-                        target = c
+            for chunk in self.chunks:
+                if chunk.file_path == source and chunk.start_line <= line <= chunk.end_line:
+                    if line < chunk.end_line:
+                        target = chunk
                         break
                     if fallback is None:
-                        fallback = c
+                        fallback = chunk
             target = target or fallback
         if target is None:
             return []

--- a/src/semble/index/index.py
+++ b/src/semble/index/index.py
@@ -4,7 +4,6 @@ import subprocess
 import tempfile
 from collections import defaultdict
 from pathlib import Path
-from typing import overload
 
 import numpy as np
 import numpy.typing as npt
@@ -155,45 +154,14 @@ class SembleIndex:
 
             return index
 
-    @overload
-    def find_related(self, source: Chunk | SearchResult, *, top_k: int = ...) -> list[SearchResult]: ...
+    def find_related(self, source: Chunk | SearchResult, *, top_k: int = 5) -> list[SearchResult]:
+        """Return chunks semantically similar to the given chunk or search result.
 
-    @overload
-    def find_related(self, source: str, line: int, *, top_k: int = ...) -> list[SearchResult]: ...
-
-    def find_related(
-        self, source: Chunk | SearchResult | str, line: int | None = None, *, top_k: int = 5
-    ) -> list[SearchResult]:
-        """Return chunks semantically similar to a given chunk or file location.
-
-        Accepts a SearchResult or Chunk directly, or a file path string with a line number.
-
-        :param source: A SearchResult, Chunk, or file path string.
-        :param line: Line number (1-indexed). Required when source is a file path string.
+        :param source: A SearchResult or Chunk to use as the seed.
         :param top_k: Number of similar chunks to return.
         :return: Ranked list of SearchResult objects, most similar first.
-        :raises TypeError: If source is a string but line is not provided.
         """
-        if isinstance(source, SearchResult):
-            target: Chunk | None = source.chunk
-        elif isinstance(source, Chunk):
-            target = source
-        else:
-            if line is None:
-                raise TypeError("line is required when source is a file path string")
-            # Prefer exclusive end to avoid shared-boundary ambiguity; fall back to inclusive.
-            target = None
-            fallback: Chunk | None = None
-            for chunk in self.chunks:
-                if chunk.file_path == source and chunk.start_line <= line <= chunk.end_line:
-                    if line < chunk.end_line:
-                        target = chunk
-                        break
-                    if fallback is None:
-                        fallback = chunk
-            target = target or fallback
-        if target is None:
-            return []
+        target = source.chunk if isinstance(source, SearchResult) else source
         selector = self._get_selector_vector(filter_languages=[target.language]) if target.language else None
         results = search_semantic(target.content, self.model, self._semantic_index, self.chunks, top_k + 1, selector)
         return [r for r in results if r.chunk != target][:top_k]

--- a/src/semble/index/index.py
+++ b/src/semble/index/index.py
@@ -4,6 +4,7 @@ import subprocess
 import tempfile
 from collections import defaultdict
 from pathlib import Path
+from typing import overload
 
 import numpy as np
 import numpy.typing as npt
@@ -154,21 +155,40 @@ class SembleIndex:
 
             return index
 
-    def find_related(self, file_path: str, line: int, top_k: int = 5) -> list[SearchResult]:
-        """Return chunks semantically similar to the chunk at the given file location.
+    @overload
+    def find_related(self, source: Chunk | SearchResult, *, top_k: int = ...) -> list[SearchResult]: ...
 
-        :param file_path: Path to the file, in the same format stored by the index.
-            For both `from_path` and `from_git` this is a repo-relative path
-            (e.g. ``src/foo.py``).  Use `chunk.file_path` from a prior search result
-            to guarantee the correct format.
-        :param line: Line number (1-indexed) used to identify the source chunk.
+    @overload
+    def find_related(self, source: str, line: int, *, top_k: int = ...) -> list[SearchResult]: ...
+
+    def find_related(
+        self, source: Chunk | SearchResult | str, line: int | None = None, *, top_k: int = 5
+    ) -> list[SearchResult]:
+        """Return chunks semantically similar to a given chunk or file location.
+
+        Accepts three forms:
+
+        - ``find_related(result)`` — pass a :class:`SearchResult` from a prior search.
+        - ``find_related(chunk)`` — pass a :class:`Chunk` directly.
+        - ``find_related(file_path, line)`` — look up by file path and line number.
+
+        :param source: A :class:`SearchResult`, :class:`Chunk`, or file path string.
+        :param line: Line number (1-indexed). Required when ``source`` is a file path string.
         :param top_k: Number of similar chunks to return.
         :return: Ranked list of SearchResult objects, most similar first.
+        :raises TypeError: If ``source`` is a string but ``line`` is not provided.
         """
-        target = next(
-            (c for c in self.chunks if c.file_path == file_path and c.start_line <= line <= c.end_line),
-            None,
-        )
+        if isinstance(source, SearchResult):
+            target: Chunk | None = source.chunk
+        elif isinstance(source, Chunk):
+            target = source
+        else:
+            if line is None:
+                raise TypeError("line is required when source is a file path string")
+            target = next(
+                (c for c in self.chunks if c.file_path == source and c.start_line <= line <= c.end_line),
+                None,
+            )
         if target is None:
             return []
         selector = self._get_selector_vector(filter_languages=[target.language]) if target.language else None

--- a/src/semble/index/index.py
+++ b/src/semble/index/index.py
@@ -166,17 +166,13 @@ class SembleIndex:
     ) -> list[SearchResult]:
         """Return chunks semantically similar to a given chunk or file location.
 
-        Accepts three forms:
+        Accepts a SearchResult or Chunk directly, or a file path string with a line number.
 
-        - ``find_related(result)`` — pass a :class:`SearchResult` from a prior search.
-        - ``find_related(chunk)`` — pass a :class:`Chunk` directly.
-        - ``find_related(file_path, line)`` — look up by file path and line number.
-
-        :param source: A :class:`SearchResult`, :class:`Chunk`, or file path string.
-        :param line: Line number (1-indexed). Required when ``source`` is a file path string.
+        :param source: A SearchResult, Chunk, or file path string.
+        :param line: Line number (1-indexed). Required when source is a file path string.
         :param top_k: Number of similar chunks to return.
         :return: Ranked list of SearchResult objects, most similar first.
-        :raises TypeError: If ``source`` is a string but ``line`` is not provided.
+        :raises TypeError: If source is a string but line is not provided.
         """
         if isinstance(source, SearchResult):
             target: Chunk | None = source.chunk

--- a/src/semble/index/index.py
+++ b/src/semble/index/index.py
@@ -185,15 +185,19 @@ class SembleIndex:
         else:
             if line is None:
                 raise TypeError("line is required when source is a file path string")
-            # Prefer exclusive end boundary to resolve ambiguity when adjacent chunks share
-            # a boundary line (e.g. chunk A ends at 127, chunk B starts at 127).
-            target = next(
-                (c for c in self.chunks if c.file_path == source and c.start_line <= line < c.end_line),
-                None,
-            ) or next(
-                (c for c in self.chunks if c.file_path == source and c.start_line <= line <= c.end_line),
-                None,
-            )
+            # Single pass: prefer exclusive end boundary to resolve ambiguity when adjacent
+            # chunks share a boundary line (e.g. chunk A ends at 127, chunk B starts at 127).
+            # Keep the first inclusive-only match as fallback for end-of-file chunks.
+            target = None
+            fallback: Chunk | None = None
+            for c in self.chunks:
+                if c.file_path == source and c.start_line <= line <= c.end_line:
+                    if line < c.end_line:
+                        target = c
+                        break
+                    if fallback is None:
+                        fallback = c
+            target = target or fallback
         if target is None:
             return []
         selector = self._get_selector_vector(filter_languages=[target.language]) if target.language else None

--- a/src/semble/index/index.py
+++ b/src/semble/index/index.py
@@ -185,7 +185,12 @@ class SembleIndex:
         else:
             if line is None:
                 raise TypeError("line is required when source is a file path string")
+            # Prefer exclusive end boundary to resolve ambiguity when adjacent chunks share
+            # a boundary line (e.g. chunk A ends at 127, chunk B starts at 127).
             target = next(
+                (c for c in self.chunks if c.file_path == source and c.start_line <= line < c.end_line),
+                None,
+            ) or next(
                 (c for c in self.chunks if c.file_path == source and c.start_line <= line <= c.end_line),
                 None,
             )

--- a/src/semble/mcp.py
+++ b/src/semble/mcp.py
@@ -155,8 +155,8 @@ def _resolve_chunk(chunks: list[Chunk], file_path: str, line: int) -> Chunk | No
     """Return the chunk that contains *line* in *file_path*, or None.
 
     When a line sits exactly on the shared boundary between two adjacent chunks
-    (i.e. ``line == c.end_line``), prefer the chunk where the line is strictly
-    interior (``line < c.end_line``).  The boundary chunk is used as a fallback
+    (i.e. ``line == chunk.end_line``), prefer the chunk where the line is strictly
+    interior (``line < chunk.end_line``).  The boundary chunk is used as a fallback
     for the final chunk in a file, where ``end_line`` is inclusive.
 
     :param chunks: All indexed chunks to search.
@@ -165,12 +165,12 @@ def _resolve_chunk(chunks: list[Chunk], file_path: str, line: int) -> Chunk | No
     :return: The best-matching Chunk, or None if not found.
     """
     fallback = None
-    for c in chunks:
-        if c.file_path == file_path and c.start_line <= line <= c.end_line:
-            if line < c.end_line:
-                return c
+    for chunk in chunks:
+        if chunk.file_path == file_path and chunk.start_line <= line <= chunk.end_line:
+            if line < chunk.end_line:
+                return chunk
             if fallback is None:
-                fallback = c
+                fallback = chunk
     return fallback
 
 

--- a/src/semble/mcp.py
+++ b/src/semble/mcp.py
@@ -10,7 +10,7 @@ from pydantic import Field
 
 from semble.index import SembleIndex
 from semble.index.dense import load_model
-from semble.types import Encoder, SearchResult
+from semble.types import Chunk, Encoder, SearchResult
 
 _REPO_DESCRIPTION = (
     "Git URL (e.g. https://github.com/org/repo) or local path to index and search. "
@@ -89,15 +89,7 @@ def create_server(cache: _IndexCache, default_source: str | None = None) -> Fast
             index = await cache.get(source)
         except Exception as exc:
             return f"Failed to index {source!r}: {exc}"
-        # Resolve file_path + line to a chunk, preferring exclusive end to avoid
-        # shared-boundary ambiguity.
-        chunk = next(
-            (c for c in index.chunks if c.file_path == file_path and c.start_line <= line < c.end_line),
-            None,
-        ) or next(
-            (c for c in index.chunks if c.file_path == file_path and c.start_line <= line <= c.end_line),
-            None,
-        )
+        chunk = _resolve_chunk(index.chunks, file_path, line)
         if chunk is None:
             return (
                 f"No chunk found at {file_path}:{line}. "
@@ -157,6 +149,29 @@ class _IndexCache:
             # Build failed: evict so the next caller can retry.
             self._tasks.pop(cache_key, None)
             raise
+
+
+def _resolve_chunk(chunks: list[Chunk], file_path: str, line: int) -> Chunk | None:
+    """Return the chunk that contains *line* in *file_path*, or None.
+
+    When a line sits exactly on the shared boundary between two adjacent chunks
+    (i.e. ``line == c.end_line``), prefer the chunk where the line is strictly
+    interior (``line < c.end_line``).  The boundary chunk is used as a fallback
+    for the final chunk in a file, where ``end_line`` is inclusive.
+
+    :param chunks: All indexed chunks to search.
+    :param file_path: File path as stored in the index.
+    :param line: 1-indexed line number to resolve.
+    :return: The best-matching Chunk, or None if not found.
+    """
+    fallback = None
+    for c in chunks:
+        if c.file_path == file_path and c.start_line <= line <= c.end_line:
+            if line < c.end_line:
+                return c
+            if fallback is None:
+                fallback = c
+    return fallback
 
 
 _GIT_URL_SCHEMES = ("https://", "http://", "ssh://", "git://", "git+ssh://", "file://")

--- a/src/semble/mcp.py
+++ b/src/semble/mcp.py
@@ -28,12 +28,11 @@ def create_server(cache: _IndexCache, default_source: str | None = None) -> Fast
     server = FastMCP(
         "semble",
         instructions=(
-            "Use this server to search any codebase by source code. "
-            "When the user asks how a library or project works, call `search` with the "
-            "GitHub URL of the relevant repository as `repo` and a natural-language query. "
-            "Resolve the GitHub URL from your training knowledge (e.g. a PyPI package name "
-            "maps to its source repo). Always prefer `search` over Grep, Glob, or Read for "
-            "any question about how code works."
+            "Instant code search for any local or GitHub repository. "
+            "Call `search` to find relevant code; call `find_related` on a result to discover similar code elsewhere. "
+            "For questions about a library (e.g. a PyPI/npm package), resolve the GitHub URL from your training "
+            "knowledge and pass it as `repo`. "
+            "Prefer these tools over Grep, Glob, or Read for any question about how code works."
         ),
     )
 
@@ -49,9 +48,8 @@ def create_server(cache: _IndexCache, default_source: str | None = None) -> Fast
     ) -> str:
         """Search a codebase with a natural-language or code query.
 
-        Pass a git URL or local path as `repo` to clone and index it on demand.
-        The index is cached so subsequent searches on the same repo are instant.
-        Returns the most relevant code chunks with file paths and line numbers.
+        Pass a git URL or local path as `repo` to index it on demand; indexes are cached for the session.
+        Use this to find where something is implemented, understand a library, or locate related code.
         """
         source = repo or default_source
         if not source:
@@ -80,8 +78,8 @@ def create_server(cache: _IndexCache, default_source: str | None = None) -> Fast
     ) -> str:
         """Find code chunks semantically similar to a specific location in a file.
 
-        Useful for discovering related logic elsewhere in the codebase.
-        Pass the same `repo` used in the original `search` call.
+        Use after `search` to explore related implementations or callers.
+        Pass file_path and line from a prior search result.
         """
         source = repo or default_source
         if not source:

--- a/src/semble/mcp.py
+++ b/src/semble/mcp.py
@@ -18,6 +18,10 @@ _REPO_DESCRIPTION = (
     "The index is cached after the first call, so repeat queries are fast."
 )
 
+_GIT_URL_SCHEMES = ("https://", "http://", "ssh://", "git://", "git+ssh://", "file://")
+# scp-like syntax: [user@]host:path, where host has no '/' before the ':'.
+_SCP_GIT_URL_RE = re.compile(r"^[\w.-]+@[\w.-]+:(?!/)")
+
 
 def create_server(cache: _IndexCache, default_source: str | None = None) -> FastMCP:
     """Build and return a configured FastMCP server backed by the given cache."""
@@ -41,7 +45,7 @@ def create_server(cache: _IndexCache, default_source: str | None = None) -> Fast
             Literal["hybrid", "semantic", "bm25"],
             Field(description="Search mode. 'hybrid' is best for most queries."),
         ] = "hybrid",
-        top_k: Annotated[int, Field(description="Number of results to return.", ge=1, le=20)] = 5,
+        top_k: Annotated[int, Field(description="Number of results to return.", ge=1)] = 5,
     ) -> str:
         """Search a codebase with a natural-language or code query.
 
@@ -72,7 +76,7 @@ def create_server(cache: _IndexCache, default_source: str | None = None) -> Fast
         ],
         line: Annotated[int, Field(description="Line number (1-indexed).")],
         repo: Annotated[str | None, Field(description=_REPO_DESCRIPTION)] = None,
-        top_k: Annotated[int, Field(description="Number of similar chunks to return.", ge=1, le=10)] = 5,
+        top_k: Annotated[int, Field(description="Number of similar chunks to return.", ge=1)] = 5,
     ) -> str:
         """Find code chunks semantically similar to a specific location in a file.
 
@@ -154,6 +158,10 @@ class _IndexCache:
 def _resolve_chunk(chunks: list[Chunk], file_path: str, line: int) -> Chunk | None:
     """Return the chunk that contains *line* in *file_path*, or None.
 
+    MCP tool arguments are JSON primitives (strings and ints), so the agent
+    passes file_path + line rather than a Chunk object. This function
+    reconstructs the Chunk at the MCP boundary before calling into the library.
+
     :param chunks: All indexed chunks to search.
     :param file_path: File path as stored in the index.
     :param line: 1-indexed line number to resolve.
@@ -167,11 +175,6 @@ def _resolve_chunk(chunks: list[Chunk], file_path: str, line: int) -> Chunk | No
             if fallback is None:  # line == end_line: boundary; keep as fallback for end-of-file chunks
                 fallback = chunk
     return fallback
-
-
-_GIT_URL_SCHEMES = ("https://", "http://", "ssh://", "git://", "git+ssh://", "file://")
-# scp-like syntax: [user@]host:path, where host has no '/' before the ':'.
-_SCP_GIT_URL_RE = re.compile(r"^[\w.-]+@[\w.-]+:(?!/)")
 
 
 def _is_git_url(path: str) -> bool:

--- a/src/semble/mcp.py
+++ b/src/semble/mcp.py
@@ -154,11 +154,6 @@ class _IndexCache:
 def _resolve_chunk(chunks: list[Chunk], file_path: str, line: int) -> Chunk | None:
     """Return the chunk that contains *line* in *file_path*, or None.
 
-    When a line sits exactly on the shared boundary between two adjacent chunks
-    (i.e. ``line == chunk.end_line``), prefer the chunk where the line is strictly
-    interior (``line < chunk.end_line``).  The boundary chunk is used as a fallback
-    for the final chunk in a file, where ``end_line`` is inclusive.
-
     :param chunks: All indexed chunks to search.
     :param file_path: File path as stored in the index.
     :param line: 1-indexed line number to resolve.
@@ -169,7 +164,7 @@ def _resolve_chunk(chunks: list[Chunk], file_path: str, line: int) -> Chunk | No
         if chunk.file_path == file_path and chunk.start_line <= line <= chunk.end_line:
             if line < chunk.end_line:
                 return chunk
-            if fallback is None:
+            if fallback is None:  # line == end_line: boundary; keep as fallback for end-of-file chunks
                 fallback = chunk
     return fallback
 

--- a/src/semble/mcp.py
+++ b/src/semble/mcp.py
@@ -89,12 +89,23 @@ def create_server(cache: _IndexCache, default_source: str | None = None) -> Fast
             index = await cache.get(source)
         except Exception as exc:
             return f"Failed to index {source!r}: {exc}"
-        results = index.find_related(file_path, line, top_k=top_k)
-        if not results:
+        # Resolve file_path + line to a chunk, preferring exclusive end to avoid
+        # shared-boundary ambiguity.
+        chunk = next(
+            (c for c in index.chunks if c.file_path == file_path and c.start_line <= line < c.end_line),
+            None,
+        ) or next(
+            (c for c in index.chunks if c.file_path == file_path and c.start_line <= line <= c.end_line),
+            None,
+        )
+        if chunk is None:
             return (
-                f"No related chunks found for {file_path}:{line}. "
+                f"No chunk found at {file_path}:{line}. "
                 "Make sure the file is indexed and the line number is within a known chunk."
             )
+        results = index.find_related(chunk, top_k=top_k)
+        if not results:
+            return f"No related chunks found for {file_path}:{line}."
         return _format_results(f"Chunks related to {file_path}:{line}", results)
 
     return server

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -84,29 +84,18 @@ def test_search_empty_query_returns_empty(indexed_index: SembleIndex, mode: str,
 
 
 def test_find_related(indexed_index: SembleIndex) -> None:
-    """find_related returns related chunks via all three input forms and handles edge cases."""
+    """find_related returns related chunks for a Chunk or SearchResult seed."""
     chunk = indexed_index.chunks[0]
-    via_path = indexed_index.find_related(chunk.file_path, chunk.start_line, top_k=3)
-    assert isinstance(via_path, list)
-    assert len(via_path) <= 3
-    assert all(r.chunk != chunk for r in via_path)
+    via_chunk = indexed_index.find_related(chunk, top_k=3)
+    assert isinstance(via_chunk, list)
+    assert len(via_chunk) <= 3
+    assert all(r.chunk != chunk for r in via_chunk)
 
-    # Chunk and SearchResult forms return the same results as file_path+line.
-    assert [r.chunk for r in indexed_index.find_related(chunk, top_k=3)] == [r.chunk for r in via_path]
+    # SearchResult form returns the same results as Chunk form.
     result = indexed_index.search("authenticate", top_k=1)[0]
     assert [r.chunk for r in indexed_index.find_related(result, top_k=3)] == [
         r.chunk for r in indexed_index.find_related(result.chunk, top_k=3)
     ]
-
-    # end_line boundary resolves to the same chunk as start_line.
-    assert [r.chunk for r in indexed_index.find_related(chunk.file_path, chunk.end_line, top_k=3)] == [
-        r.chunk for r in via_path
-    ]
-
-    # Unknown file returns empty; missing line raises.
-    assert indexed_index.find_related("/does/not/exist.py", 1) == []
-    with pytest.raises(TypeError, match="line is required"):
-        indexed_index.find_related("src/module.py")  # type: ignore[call-overload]
 
 
 _GIT_ENV = {

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -84,45 +84,27 @@ def test_search_empty_query_returns_empty(indexed_index: SembleIndex, mode: str,
 
 
 def test_find_related(indexed_index: SembleIndex) -> None:
-    """find_related: returns similar chunks for a known location; returns [] for an unknown file."""
+    """find_related returns related chunks via all three input forms and handles edge cases."""
     chunk = indexed_index.chunks[0]
-    results = indexed_index.find_related(chunk.file_path, chunk.start_line, top_k=3)
-    assert isinstance(results, list)
-    assert all(r.chunk != chunk for r in results)
-    assert len(results) <= 3
-
-    assert indexed_index.find_related("/does/not/exist.py", 1) == []
-
-
-def test_find_related_at_end_line_boundary(indexed_index: SembleIndex) -> None:
-    """find_related resolves correctly when line equals a chunk's end_line (the inclusive fallback path)."""
-    chunk = indexed_index.chunks[0]
-    # Query at the last line of the chunk — exercises the inclusive-only fallback.
-    results = indexed_index.find_related(chunk.file_path, chunk.end_line, top_k=3)
-    assert isinstance(results, list)
-    # Should find the same chunk as seeding by start_line.
-    via_start = indexed_index.find_related(chunk.file_path, chunk.start_line, top_k=3)
-    assert [r.chunk for r in results] == [r.chunk for r in via_start]
-
-
-def test_find_related_accepts_chunk(indexed_index: SembleIndex) -> None:
-    """find_related accepts a Chunk directly and returns the same results as the file_path form."""
-    chunk = indexed_index.chunks[0]
-    via_chunk = indexed_index.find_related(chunk, top_k=3)
     via_path = indexed_index.find_related(chunk.file_path, chunk.start_line, top_k=3)
-    assert [r.chunk for r in via_chunk] == [r.chunk for r in via_path]
+    assert isinstance(via_path, list)
+    assert len(via_path) <= 3
+    assert all(r.chunk != chunk for r in via_path)
 
+    # Chunk and SearchResult forms return the same results as file_path+line.
+    assert [r.chunk for r in indexed_index.find_related(chunk, top_k=3)] == [r.chunk for r in via_path]
+    result = indexed_index.search("authenticate", top_k=1)[0]
+    assert [r.chunk for r in indexed_index.find_related(result, top_k=3)] == [
+        r.chunk for r in indexed_index.find_related(result.chunk, top_k=3)
+    ]
 
-def test_find_related_accepts_search_result(indexed_index: SembleIndex) -> None:
-    """find_related accepts a SearchResult and returns the same results as passing the chunk."""
-    search_result = indexed_index.search("authenticate", top_k=1)[0]
-    via_result = indexed_index.find_related(search_result, top_k=3)
-    via_chunk = indexed_index.find_related(search_result.chunk, top_k=3)
-    assert [r.chunk for r in via_result] == [r.chunk for r in via_chunk]
+    # end_line boundary resolves to the same chunk as start_line.
+    assert [r.chunk for r in indexed_index.find_related(chunk.file_path, chunk.end_line, top_k=3)] == [
+        r.chunk for r in via_path
+    ]
 
-
-def test_find_related_raises_without_line(indexed_index: SembleIndex) -> None:
-    """find_related raises TypeError when a file path string is given without a line number."""
+    # Unknown file returns empty; missing line raises.
+    assert indexed_index.find_related("/does/not/exist.py", 1) == []
     with pytest.raises(TypeError, match="line is required"):
         indexed_index.find_related("src/module.py")  # type: ignore[call-overload]
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -94,6 +94,28 @@ def test_find_related(indexed_index: SembleIndex) -> None:
     assert indexed_index.find_related("/does/not/exist.py", 1) == []
 
 
+def test_find_related_accepts_chunk(indexed_index: SembleIndex) -> None:
+    """find_related accepts a Chunk directly and returns the same results as the file_path form."""
+    chunk = indexed_index.chunks[0]
+    via_chunk = indexed_index.find_related(chunk, top_k=3)
+    via_path = indexed_index.find_related(chunk.file_path, chunk.start_line, top_k=3)
+    assert [r.chunk for r in via_chunk] == [r.chunk for r in via_path]
+
+
+def test_find_related_accepts_search_result(indexed_index: SembleIndex) -> None:
+    """find_related accepts a SearchResult and returns the same results as passing the chunk."""
+    search_result = indexed_index.search("authenticate", top_k=1)[0]
+    via_result = indexed_index.find_related(search_result, top_k=3)
+    via_chunk = indexed_index.find_related(search_result.chunk, top_k=3)
+    assert [r.chunk for r in via_result] == [r.chunk for r in via_chunk]
+
+
+def test_find_related_raises_without_line(indexed_index: SembleIndex) -> None:
+    """find_related raises TypeError when a file path string is given without a line number."""
+    with pytest.raises(TypeError, match="line is required"):
+        indexed_index.find_related("src/module.py")  # type: ignore[call-overload]
+
+
 _GIT_ENV = {
     **os.environ,
     "GIT_AUTHOR_NAME": "test",

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -94,6 +94,17 @@ def test_find_related(indexed_index: SembleIndex) -> None:
     assert indexed_index.find_related("/does/not/exist.py", 1) == []
 
 
+def test_find_related_at_end_line_boundary(indexed_index: SembleIndex) -> None:
+    """find_related resolves correctly when line equals a chunk's end_line (the inclusive fallback path)."""
+    chunk = indexed_index.chunks[0]
+    # Query at the last line of the chunk — exercises the inclusive-only fallback.
+    results = indexed_index.find_related(chunk.file_path, chunk.end_line, top_k=3)
+    assert isinstance(results, list)
+    # Should find the same chunk as seeding by start_line.
+    via_start = indexed_index.find_related(chunk.file_path, chunk.start_line, top_k=3)
+    assert [r.chunk for r in results] == [r.chunk for r in via_start]
+
+
 def test_find_related_accepts_chunk(indexed_index: SembleIndex) -> None:
     """find_related accepts a Chunk directly and returns the same results as the file_path form."""
     chunk = indexed_index.chunks[0]

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from semble.mcp import _format_results, _IndexCache, _is_git_url, create_server, main, serve
+from semble.mcp import _format_results, _IndexCache, _is_git_url, _resolve_chunk, create_server, main, serve
 from semble.types import Chunk, Encoder, SearchMode, SearchResult
 from tests.conftest import make_chunk
 
@@ -40,6 +40,24 @@ async def _call_tool(
 def cache() -> _IndexCache:
     """An _IndexCache backed by a stub model."""
     return _IndexCache(model=MagicMock(spec=Encoder))
+
+
+def test_resolve_chunk() -> None:
+    """_resolve_chunk returns the correct chunk and handles boundary and miss cases."""
+    interior = make_chunk("line1\nline2\nline3", "src/a.py")  # start=1, end=3
+    boundary = make_chunk("last line", "src/a.py")  # start=1, end=1 (single-line)
+
+    # Line strictly inside a multi-line chunk hits the early-return path.
+    assert _resolve_chunk([interior], "src/a.py", 2) is interior
+
+    # Line equal to end_line of a single-line chunk hits the fallback path.
+    assert _resolve_chunk([boundary], "src/a.py", 1) is boundary
+
+    # Unknown file returns None.
+    assert _resolve_chunk([interior], "src/other.py", 1) is None
+
+    # Line out of range returns None.
+    assert _resolve_chunk([interior], "src/a.py", 99) is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from semble.mcp import _format_results, _IndexCache, _is_git_url, create_server, main, serve
-from semble.types import Encoder, SearchMode, SearchResult
+from semble.types import Chunk, Encoder, SearchMode, SearchResult
 from tests.conftest import make_chunk
 
 
@@ -22,11 +22,14 @@ async def _call_tool(
     *,
     index_method: str,
     index_return: list[SearchResult],
+    index_chunks: list[Chunk] | None = None,
     default_source: str | None = "/some/path",
 ) -> str:
     """Patch SembleIndex.from_path with a fake index and invoke the tool, returning the text."""
     fake_index = MagicMock()
     getattr(fake_index, index_method).return_value = index_return
+    if index_chunks is not None:
+        fake_index.chunks = index_chunks
     with patch("semble.mcp.SembleIndex.from_path", return_value=fake_index):
         server = create_server(cache, default_source=default_source)
         result = await server.call_tool(tool, args)
@@ -156,13 +159,14 @@ async def test_tool_index_failure(cache: _IndexCache, tool: str, args: dict[str,
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    ("tool", "args", "method", "results", "expected_substrings"),
+    ("tool", "args", "method", "results", "chunks", "expected_substrings"),
     [
         pytest.param(
             "search",
             {"query": "bar"},
             "search",
             [SearchResult(chunk=make_chunk("def bar(): pass", "src/bar.py"), score=0.9, source=SearchMode.HYBRID)],
+            None,
             ["bar", "0.900"],
             id="search_with_results",
         ),
@@ -171,6 +175,7 @@ async def test_tool_index_failure(cache: _IndexCache, tool: str, args: dict[str,
             {"query": "nothing"},
             "search",
             [],
+            None,
             ["No results found"],
             id="search_no_results",
         ),
@@ -179,16 +184,27 @@ async def test_tool_index_failure(cache: _IndexCache, tool: str, args: dict[str,
             {"file_path": "src/foo.py", "line": 1},
             "find_related",
             [SearchResult(chunk=make_chunk("class Foo: pass", "src/foo.py"), score=0.8, source=SearchMode.SEMANTIC)],
+            [make_chunk("class Foo: pass", "src/foo.py")],
             ["src/foo.py:1", "0.800"],
             id="find_related_with_results",
         ),
         pytest.param(
             "find_related",
-            {"file_path": "src/foo.py", "line": 99},
+            {"file_path": "src/foo.py", "line": 1},
             "find_related",
             [],
+            [make_chunk("class Foo: pass", "src/foo.py")],
             ["No related chunks found"],
             id="find_related_no_results",
+        ),
+        pytest.param(
+            "find_related",
+            {"file_path": "src/unknown.py", "line": 1},
+            "find_related",
+            [],
+            [],
+            ["No chunk found"],
+            id="find_related_unknown_file",
         ),
     ],
 )
@@ -198,10 +214,11 @@ async def test_tool_output(
     args: dict[str, Any],
     method: str,
     results: list[SearchResult],
+    chunks: list[Chunk] | None,
     expected_substrings: list[str],
 ) -> None:
     """Search and find_related format results (or an empty-state message) through the server."""
-    text = await _call_tool(cache, tool, args, index_method=method, index_return=results)
+    text = await _call_tool(cache, tool, args, index_method=method, index_return=results, index_chunks=chunks)
     for substring in expected_substrings:
         assert substring in text
 


### PR DESCRIPTION
This PR improves the `find_related` API, it now takes `Chunk | SearchResult` which is much clearer. There was also a pre-existing bug where adjacent chunks sharing a boundary line could non-deterministically resolve to the wrong chunk. There's also a small change to the MCP instructions to make them more focussed.