### PR TITLE
feat: Respect gitignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "numpy>=1.24.0",
     "bm25s>=0.2.0",
     "chonkie[code]==1.6.2",
+    "pathspec>=0.12",
 ]
 
 [project.optional-dependencies]

--- a/src/semble/index/file_walker.py
+++ b/src/semble/index/file_walker.py
@@ -72,6 +72,9 @@ DEFAULT_IGNORED_DIRS: frozenset[str] = frozenset(
         ".ruff_cache",
         ".cache",
         ".semble",
+        "dist",
+        "build",
+        ".eggs",
     }
 )
 
@@ -100,11 +103,8 @@ def _load_root_gitignore(root: Path) -> GitIgnoreSpec | None:
     gitignore = root / ".gitignore"
     if not gitignore.is_file():
         return None
-    try:
-        with gitignore.open("r", encoding="utf-8", errors="ignore") as f:
-            return GitIgnoreSpec.from_lines(f)
-    except OSError:
-        return None
+    with gitignore.open("r", encoding="utf-8", errors="ignore") as f:
+        return GitIgnoreSpec.from_lines(f)
 
 
 def walk_files(root: Path, extensions: frozenset[str], ignore: frozenset[str] | None = None) -> Iterator[Path]:

--- a/src/semble/index/file_walker.py
+++ b/src/semble/index/file_walker.py
@@ -99,7 +99,7 @@ def filter_extensions(extensions: frozenset[str] | None, *, include_text_files: 
 
 
 def _load_root_gitignore(root: Path) -> GitIgnoreSpec | None:
-    """Load the root-level ``.gitignore`` as a spec, if present."""
+    """Load the root-level .gitignore as a spec, if present."""
     gitignore = root / ".gitignore"
     if not gitignore.is_file():
         return None
@@ -110,22 +110,28 @@ def _load_root_gitignore(root: Path) -> GitIgnoreSpec | None:
 def walk_files(root: Path, extensions: frozenset[str], ignore: frozenset[str] | None = None) -> Iterator[Path]:
     """Yield files under root matching extensions, skipping ignored paths.
 
-    Directories matching ``DEFAULT_IGNORED_DIRS`` (plus any ``ignore`` override) are always
-    skipped. If the root contains a ``.gitignore``, its patterns are also honoured.
+    Directories matching DEFAULT_IGNORED_DIRS plus any names in ignore are always
+    skipped. If the root contains a .gitignore, its patterns are also honoured.
+
+    :param root: Root directory to walk.
+    :param extensions: Set of file extensions to include (e.g. {".py", ".js"}).
+    :param ignore: Additional directory names to ignore (e.g. {"build", "dist"}).
+    :yield: Path to each file under root matching the criteria.
+    :ytype: Path
     """
-    ignore_dirs = (ignore or frozenset()) | DEFAULT_IGNORED_DIRS
+    ignore_dirs = DEFAULT_IGNORED_DIRS | (ignore or frozenset())
     gitignore = _load_root_gitignore(root)
     for dirpath, dirnames, filenames in os.walk(root):
         rel_dir = Path(dirpath).relative_to(root)
         # Prune in-place so os.walk doesn't descend into ignored trees.
         kept: list[str] = []
-        for d in dirnames:
-            if d in ignore_dirs:
+        for dirname in dirnames:
+            if dirname in ignore_dirs:
                 continue
-            rel = (rel_dir / d).as_posix() + "/"
+            rel = (rel_dir / dirname).as_posix() + "/"
             if gitignore is not None and gitignore.match_file(rel):
                 continue
-            kept.append(d)
+            kept.append(dirname)
         dirnames[:] = kept
         for filename in sorted(filenames):
             file_path = Path(dirpath) / filename

--- a/src/semble/index/file_walker.py
+++ b/src/semble/index/file_walker.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 
+from pathspec import GitIgnoreSpec
+
 
 class FileCategory(str, Enum):
     CODE = "CODE"
@@ -64,14 +66,11 @@ DEFAULT_IGNORED_DIRS: frozenset[str] = frozenset(
         "node_modules",
         ".venv",
         "venv",
-        ".env",
         ".tox",
-        "dist",
-        "build",
-        ".eggs",
         ".mypy_cache",
         ".pytest_cache",
         ".ruff_cache",
+        ".cache",
         ".semble",
     }
 )
@@ -96,15 +95,44 @@ def filter_extensions(extensions: frozenset[str] | None, *, include_text_files: 
     return frozenset(ext for ext, spec in FILE_TYPES.items() if spec.category in categories_to_include)
 
 
+def _load_root_gitignore(root: Path) -> GitIgnoreSpec | None:
+    """Load the root-level ``.gitignore`` as a spec, if present."""
+    gitignore = root / ".gitignore"
+    if not gitignore.is_file():
+        return None
+    try:
+        with gitignore.open("r", encoding="utf-8", errors="ignore") as f:
+            return GitIgnoreSpec.from_lines(f)
+    except OSError:
+        return None
+
+
 def walk_files(root: Path, extensions: frozenset[str], ignore: frozenset[str] | None = None) -> Iterator[Path]:
-    """Yield files under root matching extensions, skipping ignored directories."""
-    # Always skip the defaults.
-    ignore = (ignore or frozenset()) | DEFAULT_IGNORED_DIRS
-    for dirpath, _, filenames in os.walk(root):
-        dirpath_as_path = Path(dirpath)
-        if set(dirpath_as_path.parts) & ignore:
-            continue
+    """Yield files under root matching extensions, skipping ignored paths.
+
+    Directories matching ``DEFAULT_IGNORED_DIRS`` (plus any ``ignore`` override) are always
+    skipped. If the root contains a ``.gitignore``, its patterns are also honoured.
+    """
+    ignore_dirs = (ignore or frozenset()) | DEFAULT_IGNORED_DIRS
+    gitignore = _load_root_gitignore(root)
+    for dirpath, dirnames, filenames in os.walk(root):
+        rel_dir = Path(dirpath).relative_to(root)
+        # Prune in-place so os.walk doesn't descend into ignored trees.
+        kept: list[str] = []
+        for d in dirnames:
+            if d in ignore_dirs:
+                continue
+            rel = (rel_dir / d).as_posix() + "/"
+            if gitignore is not None and gitignore.match_file(rel):
+                continue
+            kept.append(d)
+        dirnames[:] = kept
         for filename in sorted(filenames):
             file_path = Path(dirpath) / filename
-            if file_path.suffix.lower() in extensions:
-                yield file_path
+            if file_path.suffix.lower() not in extensions:
+                continue
+            if gitignore is not None:
+                rel_file = (rel_dir / filename).as_posix()
+                if gitignore.match_file(rel_file):
+                    continue
+            yield file_path

--- a/tests/test_file_walker.py
+++ b/tests/test_file_walker.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+
+from semble.index.file_walker import walk_files
+
+
+def _touch(path: Path, content: str = "x = 1\n") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def test_walk_files_skips_default_ignored_dirs(tmp_path: Path) -> None:
+    """Files under ``.venv``, ``node_modules``, ``.cache`` etc. are not yielded."""
+    _touch(tmp_path / "src" / "a.py")
+    _touch(tmp_path / ".venv" / "lib" / "b.py")
+    _touch(tmp_path / "node_modules" / "pkg" / "c.js")
+    _touch(tmp_path / ".cache" / "uv" / "d.py")
+
+    found = {p.relative_to(tmp_path).as_posix() for p in walk_files(tmp_path, frozenset({".py", ".js"}))}
+    assert found == {"src/a.py"}
+
+
+def test_walk_files_respects_root_gitignore(tmp_path: Path) -> None:
+    """Patterns in a root ``.gitignore`` exclude both directories and files."""
+    _touch(tmp_path / "src" / "keep.py")
+    _touch(tmp_path / "local" / "ignored.py")
+    _touch(tmp_path / "generated.py")
+    (tmp_path / ".gitignore").write_text("local/\ngenerated.py\n")
+
+    found = {p.relative_to(tmp_path).as_posix() for p in walk_files(tmp_path, frozenset({".py"}))}
+    assert found == {"src/keep.py"}
+
+
+def test_walk_files_gitignore_negation(tmp_path: Path) -> None:
+    """``!`` negation patterns re-include previously ignored files."""
+    _touch(tmp_path / "build" / "out.py")
+    _touch(tmp_path / "build" / "keep.py")
+    (tmp_path / ".gitignore").write_text("build/*\n!build/keep.py\n")
+
+    found = {p.relative_to(tmp_path).as_posix() for p in walk_files(tmp_path, frozenset({".py"}))}
+    assert found == {"build/keep.py"}
+
+
+def test_walk_files_prunes_ignored_dirs(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """Ignored directories are pruned so ``os.walk`` never descends into them."""
+    _touch(tmp_path / "src" / "a.py")
+    _touch(tmp_path / "node_modules" / "deep" / "deeper" / "b.js")
+
+    visited: list[str] = []
+    import os
+
+    real_walk = os.walk
+
+    def tracking_walk(*args, **kwargs):  # type: ignore[no-untyped-def]
+        for dirpath, dirnames, filenames in real_walk(*args, **kwargs):
+            visited.append(dirpath)
+            yield dirpath, dirnames, filenames
+
+    monkeypatch.setattr("semble.index.file_walker.os.walk", tracking_walk)
+    list(walk_files(tmp_path, frozenset({".py", ".js"})))
+    assert not any("node_modules" in v for v in visited[1:]), visited

--- a/tests/test_file_walker.py
+++ b/tests/test_file_walker.py
@@ -1,4 +1,8 @@
+import os
+from collections.abc import Iterator
 from pathlib import Path
+
+import pytest
 
 from semble.index.file_walker import walk_files
 
@@ -8,50 +12,50 @@ def _touch(path: Path, content: str = "x = 1\n") -> None:
     path.write_text(content)
 
 
-def test_walk_files_skips_default_ignored_dirs(tmp_path: Path) -> None:
-    """Files under ``.venv``, ``node_modules``, ``.cache`` etc. are not yielded."""
-    _touch(tmp_path / "src" / "a.py")
-    _touch(tmp_path / ".venv" / "lib" / "b.py")
-    _touch(tmp_path / "node_modules" / "pkg" / "c.js")
-    _touch(tmp_path / ".cache" / "uv" / "d.py")
-
-    found = {p.relative_to(tmp_path).as_posix() for p in walk_files(tmp_path, frozenset({".py", ".js"}))}
-    assert found == {"src/a.py"}
-
-
-def test_walk_files_respects_root_gitignore(tmp_path: Path) -> None:
-    """Patterns in a root ``.gitignore`` exclude both directories and files."""
-    _touch(tmp_path / "src" / "keep.py")
-    _touch(tmp_path / "local" / "ignored.py")
-    _touch(tmp_path / "generated.py")
-    (tmp_path / ".gitignore").write_text("local/\ngenerated.py\n")
+@pytest.mark.parametrize(
+    ("files", "gitignore", "expected"),
+    [
+        # Default-ignored dirs (.venv, node_modules, .cache) are always skipped.
+        (
+            ["src/a.py", ".venv/lib/b.py", "node_modules/pkg/c.py", ".cache/uv/d.py"],
+            None,
+            {"src/a.py"},
+        ),
+        # Root .gitignore excludes both directories and files.
+        (
+            ["src/keep.py", "local/ignored.py", "generated.py"],
+            "local/\ngenerated.py\n",
+            {"src/keep.py"},
+        ),
+        # Negation (`!`) patterns re-include previously ignored files.
+        (
+            ["out/a.py", "out/keep.py"],
+            "out/*\n!out/keep.py\n",
+            {"out/keep.py"},
+        ),
+    ],
+)
+def test_walk_files_filtering(tmp_path: Path, files: list[str], gitignore: str | None, expected: set[str]) -> None:
+    """Directory defaults, gitignore patterns, and negations filter the yielded files."""
+    for rel in files:
+        _touch(tmp_path / rel)
+    if gitignore is not None:
+        (tmp_path / ".gitignore").write_text(gitignore)
 
     found = {p.relative_to(tmp_path).as_posix() for p in walk_files(tmp_path, frozenset({".py"}))}
-    assert found == {"src/keep.py"}
+    assert found == expected
 
 
-def test_walk_files_gitignore_negation(tmp_path: Path) -> None:
-    """``!`` negation patterns re-include previously ignored files."""
-    _touch(tmp_path / "build" / "out.py")
-    _touch(tmp_path / "build" / "keep.py")
-    (tmp_path / ".gitignore").write_text("build/*\n!build/keep.py\n")
-
-    found = {p.relative_to(tmp_path).as_posix() for p in walk_files(tmp_path, frozenset({".py"}))}
-    assert found == {"build/keep.py"}
-
-
-def test_walk_files_prunes_ignored_dirs(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_walk_files_prunes_ignored_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Ignored directories are pruned so ``os.walk`` never descends into them."""
     _touch(tmp_path / "src" / "a.py")
     _touch(tmp_path / "node_modules" / "deep" / "deeper" / "b.js")
 
     visited: list[str] = []
-    import os
-
     real_walk = os.walk
 
-    def tracking_walk(*args, **kwargs):  # type: ignore[no-untyped-def]
-        for dirpath, dirnames, filenames in real_walk(*args, **kwargs):
+    def tracking_walk(top: str) -> Iterator[tuple[str, list[str], list[str]]]:
+        for dirpath, dirnames, filenames in real_walk(top):
             visited.append(dirpath)
             yield dirpath, dirnames, filenames
 

--- a/tests/test_file_walker.py
+++ b/tests/test_file_walker.py
@@ -8,6 +8,7 @@ from semble.index.file_walker import walk_files
 
 
 def _touch(path: Path, content: str = "x = 1\n") -> None:
+    """Create path (and any missing parents) and write content to it."""
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content)
 
@@ -47,7 +48,7 @@ def test_walk_files_filtering(tmp_path: Path, files: list[str], gitignore: str |
 
 
 def test_walk_files_prunes_ignored_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Ignored directories are pruned so ``os.walk`` never descends into them."""
+    """Ignored directories are pruned so os.walk never descends into them."""
     _touch(tmp_path / "src" / "a.py")
     _touch(tmp_path / "node_modules" / "deep" / "deeper" / "b.js")
 

--- a/uv.lock
+++ b/uv.lock
@@ -3058,6 +3058,7 @@ dependencies = [
     { name = "model2vec" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pathspec" },
     { name = "vicinity" },
 ]
 
@@ -3092,6 +3093,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "numpy", specifier = ">=1.24.0" },
     { name = "numpy", marker = "extra == 'benchmark'", specifier = ">=1.24.0" },
+    { name = "pathspec", specifier = ">=0.12" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "pydoclint", marker = "extra == 'dev'", specifier = ">=0.5.3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },


### PR DESCRIPTION
This PR adds support for reading gitignore to know what not to index. This is much safer than keeping a custom ignore list. The custom ignore list is kept as a fallback.