### PR TITLE
Exclude uv.lock

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-exclude benchmarks *
 recursive-exclude assets *
 recursive-exclude src *.egg-info
+exclude uv.lock


### PR DESCRIPTION
Reduces the downloadable package size by quite a lot.