### PR TITLE
Add macOS to CI workflow matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "windows-latest"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:


### PR DESCRIPTION
This pull request makes a minor update to the CI workflow by adding macOS to the matrix of operating systems tested. This ensures that the project is tested on Ubuntu, macOS, and Windows environments.

* Added `macos-latest` to the `os` matrix in the GitHub Actions CI workflow (`.github/workflows/ci.yaml`).