### PR TITLE
refactor: dedup SembleIndex builders and MCP tool preamble

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,4 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+.serena/

--- a/benchmarks/baselines/coderankembed.py
+++ b/benchmarks/baselines/coderankembed.py
@@ -3,6 +3,7 @@ import json
 import sys
 import time
 from collections import defaultdict
+from collections.abc import Sequence
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
@@ -29,7 +30,8 @@ _LATENCY_RUNS = 3  # transformer inference is slow; keep runs low
 
 
 class _AsymmetricWrapper:
-    """Wrap SentenceTransformer with asymmetric query/document prompts.
+    """
+    Wrap SentenceTransformer with asymmetric query/document prompts.
 
     Single-element lists are treated as queries; larger batches as documents.
     max_seq_length is capped to avoid OOM on CPU with long chunks.
@@ -39,11 +41,12 @@ class _AsymmetricWrapper:
         self._model = model
         self._model.max_seq_length = max_seq_length
 
-    def encode(self, texts: list[str]) -> np.ndarray:
+    def encode(self, texts: Sequence[str], /) -> np.ndarray:
         """Encode texts with query or document prompt based on batch size."""
-        if len(texts) == 1:
-            return self._model.encode(texts, prompt_name="query", batch_size=1)  # type: ignore[return-value]
-        return self._model.encode(texts, batch_size=1)  # type: ignore[return-value]
+        batch = list(texts)
+        if len(batch) == 1:
+            return self._model.encode(batch, prompt_name="query", batch_size=1)  # type: ignore[return-value]
+        return self._model.encode(batch, batch_size=1)  # type: ignore[return-value]
 
 
 @dataclass(frozen=True)

--- a/benchmarks/baselines/colgrep.py
+++ b/benchmarks/baselines/colgrep.py
@@ -88,7 +88,8 @@ def _evaluate_repo(
 
 
 def _init_index(path: Path) -> tuple[bool, float]:
-    """Build (or rebuild) the colgrep index at path; return (non_empty, elapsed_ms).
+    """
+    Build (or rebuild) the colgrep index at path; return (non_empty, elapsed_ms).
 
     :param path: Directory to index.
     :return: Tuple of (non_empty, index_ms) where non_empty is False if colgrep reported 0 files.
@@ -106,7 +107,8 @@ def _init_index(path: Path) -> tuple[bool, float]:
 
 
 def _resolve_path(spec: RepoSpec) -> tuple[Path, float]:
-    """Return the path ColGREP should index and elapsed index build time.
+    """
+    Return the path ColGREP should index and elapsed index build time.
 
     Tries benchmark_dir first; if that yields 0 files falls back to checkout_dir,
     which is the project root ColGREP needs to discover the .git boundary.

--- a/benchmarks/data.py
+++ b/benchmarks/data.py
@@ -173,7 +173,8 @@ def current_sha() -> str:
 
 
 def results_path(method: str) -> Path:
-    """Return the path where results for this method and the current HEAD SHA will be saved.
+    """
+    Return the path where results for this method and the current HEAD SHA will be saved.
 
     :param method: Short tool/method label (e.g. 'ripgrep', 'colgrep').
     :return: Path of the form benchmarks/results/<method>-<sha12>.json.
@@ -185,7 +186,8 @@ def results_path(method: str) -> Path:
 
 
 def save_results(method: str, payload: object) -> Path:
-    """Write payload to benchmarks/results/<method>-<sha12>.json and return the path.
+    """
+    Write payload to benchmarks/results/<method>-<sha12>.json and return the path.
 
     :param method: Short tool/method label used as the filename prefix (e.g. 'ripgrep').
     :param payload: JSON-serialisable object to write.

--- a/benchmarks/run_benchmark.py
+++ b/benchmarks/run_benchmark.py
@@ -1,5 +1,4 @@
 import argparse
-import json
 import sys
 import time
 from collections import defaultdict

--- a/benchmarks/speed_benchmark.py
+++ b/benchmarks/speed_benchmark.py
@@ -194,7 +194,7 @@ def _bench_colgrep(spec: RepoSpec, tasks: list[Task]) -> tuple[float, tuple[floa
     if proc.returncode != 0:
         print(f"  WARNING: colgrep init failed: {proc.stderr.strip()}", file=sys.stderr)
     if "(0 files)" in proc.stdout or "(0 files)" in proc.stderr:
-        print(f"  SKIP: colgrep indexed 0 files (unsupported language?)", file=sys.stderr)
+        print("  SKIP: colgrep indexed 0 files (unsupported language?)", file=sys.stderr)
         return None
     latencies: list[float] = []
     code_only = spec.language != "bash"

--- a/src/semble/index/create.py
+++ b/src/semble/index/create.py
@@ -20,7 +20,8 @@ def create_index_from_path(
     include_text_files: bool = False,
     display_root: Path | None = None,
 ) -> tuple[bm25s.BM25, SelectableBasicBackend, list[Chunk]]:
-    """Create an index from a resolved directory, optionally storing chunk paths relative to display_root.
+    """
+    Create an index from a resolved directory, optionally storing chunk paths relative to display_root.
 
     :param path: Resolved absolute path to index.
     :param model: The model to use for indexing.

--- a/src/semble/index/dense.py
+++ b/src/semble/index/dense.py
@@ -2,7 +2,6 @@ import numpy as np
 import numpy.typing as npt
 from huggingface_hub.utils.tqdm import disable_progress_bars
 from model2vec import StaticModel
-from numpy import typing as npt
 from vicinity.backends.basic import CosineBasicBackend
 from vicinity.datatypes import QueryResult
 from vicinity.utils import normalize
@@ -40,7 +39,8 @@ class SelectableBasicBackend(CosineBasicBackend):
         return 1 - sim
 
     def query(self, vectors: npt.NDArray, k: int, selector: npt.NDArray[np.int_] | None = None) -> QueryResult:
-        """Batched distance query.
+        """
+        Batched distance query.
 
         :param vectors: The vectors to query.
         :param k: The number of nearest neighbors to return.

--- a/src/semble/index/file_walker.py
+++ b/src/semble/index/file_walker.py
@@ -108,7 +108,8 @@ def _load_root_gitignore(root: Path) -> GitIgnoreSpec | None:
 
 
 def walk_files(root: Path, extensions: frozenset[str], ignore: frozenset[str] | None = None) -> Iterator[Path]:
-    """Yield files under root matching extensions, skipping ignored paths.
+    """
+    Yield files under root matching extensions, skipping ignored paths.
 
     Directories matching DEFAULT_IGNORED_DIRS plus any names in ignore are always
     skipped. If the root contains a .gitignore, its patterns are also honoured.

--- a/src/semble/index/index.py
+++ b/src/semble/index/index.py
@@ -25,7 +25,8 @@ class SembleIndex:
         semantic_index: SelectableBasicBackend,
         chunks: list[Chunk],
     ) -> None:
-        """Internal constructor — use :meth:`from_path` or :meth:`from_git`.
+        """
+        Internal constructor — use :meth:`from_path` or :meth:`from_git`.
 
         :param model: Embedding model to use.
         :param bm25_index: The bm25 index.
@@ -65,6 +66,27 @@ class SembleIndex:
         )
 
     @classmethod
+    def _build(
+        cls,
+        model: Encoder | None,
+        path: Path,
+        extensions: frozenset[str] | None,
+        ignore: frozenset[str] | None,
+        include_text_files: bool,
+    ) -> SembleIndex:
+        """Build a SembleIndex from an already-resolved directory path."""
+        model = model or load_model()
+        bm25, vicinity, chunks = create_index_from_path(
+            path,
+            model=model,
+            extensions=extensions,
+            ignore=ignore,
+            include_text_files=include_text_files,
+            display_root=path,
+        )
+        return cls(model, bm25, vicinity, chunks)
+
+    @classmethod
     def from_path(
         cls,
         path: str | Path,
@@ -73,7 +95,8 @@ class SembleIndex:
         ignore: frozenset[str] | None = None,
         include_text_files: bool = False,
     ) -> SembleIndex:
-        """Create and index a SembleIndex from a directory.
+        """
+        Create and index a SembleIndex from a directory.
 
         :param path: Root directory to index.
         :param model: Embedding model to use. Defaults to potion-code-16M.
@@ -84,25 +107,12 @@ class SembleIndex:
         :raises FileNotFoundError: If `path` does not exist.
         :raises NotADirectoryError: If `path` exists but is not a directory.
         """
-        model = model or load_model()
         path = Path(path)
         if not path.exists():
             raise FileNotFoundError(f"Path does not exist: {path}")
         if not path.is_dir():
             raise NotADirectoryError(f"Path is not a directory: {path}")
-        path = path.resolve()
-        bm25, vicinity, chunks = create_index_from_path(
-            path,
-            model=model,
-            extensions=extensions,
-            ignore=ignore,
-            include_text_files=include_text_files,
-            display_root=path,
-        )
-
-        index = SembleIndex(model, bm25, vicinity, chunks)
-
-        return index
+        return cls._build(model, path.resolve(), extensions, ignore, include_text_files)
 
     @classmethod
     def from_git(
@@ -114,7 +124,8 @@ class SembleIndex:
         ignore: frozenset[str] | None = None,
         include_text_files: bool = False,
     ) -> SembleIndex:
-        """Clone a git repository and index it.
+        """
+        Clone a git repository and index it.
 
         The repository is cloned into a temporary directory that is removed once
         indexing finishes. Chunk content is preserved in-memory, but
@@ -139,23 +150,11 @@ class SembleIndex:
                 raise RuntimeError("git is not installed or not on PATH") from None
             if result.returncode != 0:
                 raise RuntimeError(f"git clone failed for {url!r}:\n{result.stderr.strip()}")
-            model = model or load_model()
-            resolved_path = Path(tmp_dir).resolve()
-            bm25, vicinity, chunks = create_index_from_path(
-                resolved_path,
-                model=model,
-                extensions=extensions,
-                ignore=ignore,
-                include_text_files=include_text_files,
-                display_root=resolved_path,
-            )
-
-            index = SembleIndex(model, bm25, vicinity, chunks)
-
-            return index
+            return cls._build(model, Path(tmp_dir).resolve(), extensions, ignore, include_text_files)
 
     def find_related(self, source: Chunk | SearchResult, *, top_k: int = 5) -> list[SearchResult]:
-        """Return chunks semantically similar to the given chunk or search result.
+        """
+        Return chunks semantically similar to the given chunk or search result.
 
         :param source: A SearchResult or Chunk to use as the seed.
         :param top_k: Number of similar chunks to return.
@@ -187,7 +186,8 @@ class SembleIndex:
         filter_languages: list[str] | None = None,
         filter_paths: list[str] | None = None,
     ) -> list[SearchResult]:
-        """Search the index and return the top-k most relevant chunks.
+        """
+        Search the index and return the top-k most relevant chunks.
 
         :param query: Natural-language or keyword query string.
         :param top_k: Maximum number of results to return.

--- a/src/semble/index/sparse.py
+++ b/src/semble/index/sparse.py
@@ -16,7 +16,8 @@ def selector_to_mask(selector: npt.NDArray[np.int_] | None, size: int) -> npt.ND
 
 
 def enrich_for_bm25(chunk: Chunk) -> str:
-    """Append file path components to BM25 content to boost path-based queries.
+    """
+    Append file path components to BM25 content to boost path-based queries.
 
     Assumes ``chunk.file_path`` is already repo-relative (set by ``create_index_from_path``)
     so machine-specific directory components are never indexed.

--- a/src/semble/mcp.py
+++ b/src/semble/mcp.py
@@ -46,21 +46,15 @@ def create_server(cache: _IndexCache, default_source: str | None = None) -> Fast
         ] = "hybrid",
         top_k: Annotated[int, Field(description="Number of results to return.", ge=1)] = 5,
     ) -> str:
-        """Search a codebase with a natural-language or code query.
+        """
+        Search a codebase with a natural-language or code query.
 
         Pass a git URL or local path as `repo` to index it on demand; indexes are cached for the session.
         Use this to find where something is implemented, understand a library, or locate related code.
         """
-        source = repo or default_source
-        if not source:
-            return (
-                "No repo specified and no default index. "
-                "Pass a git URL (https://github.com/...) or local path as `repo`."
-            )
-        try:
-            index = await cache.get(source)
-        except Exception as exc:
-            return f"Failed to index {source!r}: {exc}"
+        index = await _get_index_or_error(cache, repo, default_source)
+        if isinstance(index, str):
+            return index
         results = index.search(query, top_k=top_k, mode=mode)
         if not results:
             return "No results found."
@@ -76,21 +70,15 @@ def create_server(cache: _IndexCache, default_source: str | None = None) -> Fast
         repo: Annotated[str | None, Field(description=_REPO_DESCRIPTION)] = None,
         top_k: Annotated[int, Field(description="Number of similar chunks to return.", ge=1)] = 5,
     ) -> str:
-        """Find code chunks semantically similar to a specific location in a file.
+        """
+        Find code chunks semantically similar to a specific location in a file.
 
         Use after `search` to explore related implementations or callers.
         Pass file_path and line from a prior search result.
         """
-        source = repo or default_source
-        if not source:
-            return (
-                "No repo specified and no default index. "
-                "Pass a git URL (https://github.com/...) or local path as `repo`."
-            )
-        try:
-            index = await cache.get(source)
-        except Exception as exc:
-            return f"Failed to index {source!r}: {exc}"
+        index = await _get_index_or_error(cache, repo, default_source)
+        if isinstance(index, str):
+            return index
         chunk = _resolve_chunk(index.chunks, file_path, line)
         if chunk is None:
             return (
@@ -153,8 +141,22 @@ class _IndexCache:
             raise
 
 
+async def _get_index_or_error(cache: _IndexCache, repo: str | None, default_source: str | None) -> SembleIndex | str:
+    """Resolve a repo source to an index, or return an error message string."""
+    source = repo or default_source
+    if not source:
+        return (
+            "No repo specified and no default index. Pass a git URL (https://github.com/...) or local path as `repo`."
+        )
+    try:
+        return await cache.get(source)
+    except Exception as exc:
+        return f"Failed to index {source!r}: {exc}"
+
+
 def _resolve_chunk(chunks: list[Chunk], file_path: str, line: int) -> Chunk | None:
-    """Return the chunk that contains *line* in *file_path*, or None.
+    """
+    Return the chunk that contains *line* in *file_path*, or None.
 
     MCP tool arguments are JSON primitives (strings and ints), so the agent
     passes file_path + line rather than a Chunk object. This function

--- a/src/semble/ranking/boosting.py
+++ b/src/semble/ranking/boosting.py
@@ -145,7 +145,8 @@ def _is_symbol_query(query: str) -> bool:
 
 
 def _extract_symbol_name(query: str) -> str:
-    """Extract the final identifier from a possibly namespace-qualified query.
+    """
+    Extract the final identifier from a possibly namespace-qualified query.
 
     Examples: "Sinatra::Base" → "Base", "Client" → "Client".
     """
@@ -167,7 +168,8 @@ def _definition_pattern(symbol_name: str) -> tuple[re.Pattern[str], re.Pattern[s
 
 
 def _chunk_defines_symbol(chunk: Chunk, symbol_name: str) -> bool:
-    """Return True if the chunk contains a definition of *symbol_name*.
+    """
+    Return True if the chunk contains a definition of *symbol_name*.
 
     Case-sensitive for general keywords, case-insensitive for SQL DDL.
     Also matches namespace-qualified forms (e.g. ``defmodule Phoenix.Router`` for ``Router``).
@@ -240,7 +242,8 @@ def _boost_embedded_symbols(
     max_score: float,
     all_chunks: list[Chunk],
 ) -> None:
-    """Boost chunks defining CamelCase/camelCase symbols embedded in NL queries (in-place).
+    """
+    Boost chunks defining CamelCase/camelCase symbols embedded in NL queries (in-place).
 
     Half-strength vs pure symbol queries. Non-candidate scan uses stem-prefix match
     so e.g. ``state.ts`` is found for symbol ``StateManager``.
@@ -293,7 +296,8 @@ def _boost_stem_matches(
     query: str,
     max_score: float,
 ) -> None:
-    """Boost chunks whose file paths match NL query keywords (in-place).
+    """
+    Boost chunks whose file paths match NL query keywords (in-place).
 
     Uses prefix matching for morphological variants (e.g. "dependency" matches
     "dependencies").  Matches file stems and the immediate parent directory name.

--- a/src/semble/ranking/penalties.py
+++ b/src/semble/ranking/penalties.py
@@ -84,7 +84,8 @@ def rerank_topk(
     *,
     penalise_paths: bool = True,
 ) -> list[tuple[Chunk, float]]:
-    """Select top-k results with optional file-path penalties and file-saturation decay.
+    """
+    Select top-k results with optional file-path penalties and file-saturation decay.
 
     When `penalise_paths` is True, path penalties are applied before sorting.
     Saturation decay is applied greedily during the greedy pass; because decay

--- a/src/semble/search.py
+++ b/src/semble/search.py
@@ -77,7 +77,8 @@ def search_hybrid(
     alpha: float | None = None,
     selector: npt.NDArray[np.int_] | None = None,
 ) -> list[SearchResult]:
-    """Hybrid search: alpha-weighted combination of semantic and BM25 scores.
+    """
+    Hybrid search: alpha-weighted combination of semantic and BM25 scores.
 
     Both score sets are converted to RRF scores before combining, so alpha has
     a consistent meaning regardless of raw score magnitude.

--- a/src/semble/tokens.py
+++ b/src/semble/tokens.py
@@ -10,7 +10,8 @@ _CAMEL_RE = re.compile(r"[A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+|[0-9]+")
 
 
 def split_identifier(token: str) -> list[str]:
-    """Split a single identifier into sub-tokens via camelCase/snake_case.
+    """
+    Split a single identifier into sub-tokens via camelCase/snake_case.
 
     Returns the original token (lowered) plus any sub-tokens.
     E.g. "HandlerStack" -> ["handlerstack", "handler", "stack"]
@@ -33,7 +34,8 @@ def split_identifier(token: str) -> list[str]:
 
 
 def tokenize(text: str) -> list[str]:
-    """Split text into lowercase identifier-like tokens for BM25 indexing.
+    """
+    Split text into lowercase identifier-like tokens for BM25 indexing.
 
     Compound identifiers (camelCase, PascalCase, snake_case) are expanded
     into sub-tokens so that partial matches work. The original compound


### PR DESCRIPTION
`SembleIndex.from_path` and `from_git` shared a 5-line tail (load_model fallback, `create_index_from_path` call, constructor). Extracted into a private `_build` classmethod so each public entrypoint focuses on its own concern: `from_path` validates filesystem paths, `from_git` handles cloning.

The `search` and `find_related` MCP tools shared a 7-line preamble for repo resolution and index lookup. Extracted into `_get_index_or_error` so each tool body focuses on its own logic.

The first commit applies a repo-wide ruff D213 docstring auto-fix that the pre-commit hook produced, plus a pre-existing mypy fix in the benchmarks (`_AsymmetricWrapper.encode` now matches the `Encoder` protocol). It also adds `.serena/` to `.gitignore`.