### PR TITLE
Add live refresh: persistence, git hook, file watcher

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "bm25s>=0.2.0",
     "chonkie[code]==1.6.2",
     "pathspec>=0.12",
+    "watchdog>=4.0",
 ]
 
 [project.optional-dependencies]

--- a/src/semble/cli.py
+++ b/src/semble/cli.py
@@ -8,7 +8,19 @@ from semble.index import SembleIndex
 from semble.utils import _format_results, _is_git_url, _resolve_chunk
 
 _CLAUDE_FILE_PATH = Path(".claude") / "agents" / "semble-search.md"
-_CLI_DISPATCH_ARGS = frozenset({"search", "find-related", "init", "-h", "--help"})
+_CLI_DISPATCH_ARGS = frozenset(
+    {
+        "search",
+        "find-related",
+        "init",
+        "reindex",
+        "watch",
+        "install-hooks",
+        "uninstall-hooks",
+        "-h",
+        "--help",
+    }
+)
 
 
 def main() -> None:
@@ -70,10 +82,87 @@ def _cli_main() -> None:
     init_p = sub.add_parser("init", help="Write .claude/agents/semble-search.md for Claude Code sub-agent support.")
     init_p.add_argument("--force", action="store_true", help="Overwrite if the file already exists.")
 
+    reindex_p = sub.add_parser("reindex", help="Re-index a local path; persists to <path>/.semble.")
+    reindex_p.add_argument("path", nargs="?", default=".", help="Local path to (re-)index (default: current directory).")
+    reindex_p.add_argument(
+        "--full",
+        action="store_true",
+        help="Force a full rebuild even if a cached index exists.",
+    )
+
+    watch_p = sub.add_parser("watch", help="Watch a local path and re-index on file changes.")
+    watch_p.add_argument("path", nargs="?", default=".", help="Local path to watch (default: current directory).")
+    watch_p.add_argument(
+        "--debounce",
+        type=float,
+        default=0.5,
+        help="Seconds to coalesce events before refresh (default: 0.5).",
+    )
+
+    hooks_p = sub.add_parser("install-hooks", help="Install a post-commit hook that runs `semble reindex`.")
+    hooks_p.add_argument("path", nargs="?", default=".", help="Repository root (default: current directory).")
+    hooks_p.add_argument("--force", action="store_true", help="Overwrite a non-semble hook if present.")
+
+    unhooks_p = sub.add_parser("uninstall-hooks", help="Remove a previously installed semble post-commit hook.")
+    unhooks_p.add_argument("path", nargs="?", default=".", help="Repository root (default: current directory).")
+
     args = parser.parse_args()
 
     if args.command == "init":
         _run_init(force=args.force)
+        return
+
+    if args.command == "install-hooks":
+        from semble.hooks import install_hook
+
+        try:
+            written = install_hook(args.path, force=args.force)
+        except (FileExistsError, RuntimeError) as exc:
+            print(str(exc), file=sys.stderr)
+            sys.exit(1)
+        print(f"Installed semble post-commit hook at {written}")
+        return
+
+    if args.command == "uninstall-hooks":
+        from semble.hooks import uninstall_hook
+
+        removed = uninstall_hook(args.path)
+        print("Removed semble post-commit hook." if removed else "No semble-managed hook found.")
+        return
+
+    if args.command == "reindex":
+        from semble.index.dense import _DEFAULT_MODEL_NAME, load_model
+        from semble.persistence import cache_dir_for, load_index
+
+        root = Path(args.path).resolve()
+        cdir = cache_dir_for(root)
+        model = load_model()
+        if args.full:
+            SembleIndex.from_path(root, model=model, cache_dir=cdir, model_name=_DEFAULT_MODEL_NAME)
+            print(f"Full reindex of {root} → {cdir}")
+        else:
+            existing = load_index(cdir, model=model)
+            if existing is None:
+                SembleIndex.from_path(root, model=model, cache_dir=cdir, model_name=_DEFAULT_MODEL_NAME)
+                print(f"Built initial index for {root} → {cdir}")
+            else:
+                existing.refresh()  # full refresh; incremental is exposed only programmatically.
+                print(f"Refreshed index at {cdir}")
+        return
+
+    if args.command == "watch":
+        from semble.index.dense import _DEFAULT_MODEL_NAME, load_model
+        from semble.persistence import cache_dir_for, load_index
+        from semble.watch import watch as run_watch
+
+        root = Path(args.path).resolve()
+        cdir = cache_dir_for(root)
+        model = load_model()
+        index = load_index(cdir, model=model)
+        if index is None:
+            index = SembleIndex.from_path(root, model=model, cache_dir=cdir, model_name=_DEFAULT_MODEL_NAME)
+            print(f"Built initial index for {root}")
+        run_watch(index, debounce_seconds=args.debounce)
         return
 
     index = SembleIndex.from_git(args.path) if _is_git_url(args.path) else SembleIndex.from_path(args.path)

--- a/src/semble/hooks.py
+++ b/src/semble/hooks.py
@@ -1,0 +1,71 @@
+"""Git hook installation helpers."""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+HOOK_MARKER = "# semble-managed hook"
+HOOK_TEMPLATE = """#!/usr/bin/env bash
+{marker}
+# Re-index the repo after each commit so MCP/CLI search reflects the new state.
+# Remove this hook with: semble uninstall-hooks
+set -e
+ROOT="$(git rev-parse --show-toplevel)"
+exec semble reindex "$ROOT" >/dev/null 2>&1 || true
+"""
+
+
+def _git_dir(repo: Path) -> Path:
+    """Return the .git directory for ``repo`` (handles worktrees and gitdir files)."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--git-path", "hooks"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return (repo / result.stdout.strip()).resolve()
+
+
+def install_hook(repo: str | Path, hook_name: str = "post-commit", force: bool = False) -> Path:
+    """Write a semble-managed git hook into ``repo``. Returns the path written.
+
+    :raises FileExistsError: If a non-semble hook already exists and ``force`` is False.
+    :raises RuntimeError: If ``repo`` is not a git repository.
+    """
+    repo_path = Path(repo).resolve()
+    if not (repo_path / ".git").exists() and not (repo_path / ".git").is_file():
+        raise RuntimeError(f"{repo_path} is not a git repository")
+    hooks_dir = _git_dir(repo_path)
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    hook_path = hooks_dir / hook_name
+    if hook_path.exists() and not force:
+        existing = hook_path.read_text(encoding="utf-8", errors="ignore")
+        if HOOK_MARKER not in existing:
+            raise FileExistsError(
+                f"{hook_path} already exists and is not semble-managed. Re-run with --force to overwrite."
+            )
+    hook_path.write_text(HOOK_TEMPLATE.format(marker=HOOK_MARKER), encoding="utf-8")
+    mode = hook_path.stat().st_mode
+    hook_path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return hook_path
+
+
+def uninstall_hook(repo: str | Path, hook_name: str = "post-commit") -> bool:
+    """Remove the semble-managed hook if present. Returns True if removed."""
+    repo_path = Path(repo).resolve()
+    try:
+        hooks_dir = _git_dir(repo_path)
+    except subprocess.CalledProcessError:
+        return False
+    hook_path = hooks_dir / hook_name
+    if not hook_path.exists():
+        return False
+    content = hook_path.read_text(encoding="utf-8", errors="ignore")
+    if HOOK_MARKER not in content:
+        return False
+    os.unlink(hook_path)
+    return True

--- a/src/semble/index/index.py
+++ b/src/semble/index/index.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 
+import contextlib
 import subprocess
 import tempfile
 from collections import defaultdict
+from collections.abc import Iterable
 from pathlib import Path
 
 import numpy as np
 import numpy.typing as npt
 from bm25s import BM25
 
+from semble.index.chunker import chunk_source
 from semble.index.create import create_index_from_path
-from semble.index.dense import SelectableBasicBackend, load_model
+from semble.index.dense import SelectableBasicBackend, embed_chunks, load_model
+from semble.index.file_walker import filter_extensions, language_for_path, walk_files
 from semble.search import search_bm25, search_hybrid, search_semantic
 from semble.types import Chunk, Encoder, IndexStats, SearchMode, SearchResult
 
@@ -37,6 +41,15 @@ class SembleIndex:
         self._bm25_index: BM25 = bm25_index
         self._semantic_index: SelectableBasicBackend = semantic_index
         self._file_mapping, self._language_mapping = self._populate_mapping()
+        # Live-refresh state. Populated by from_path / load_index; absent for from_git.
+        self._embeddings: npt.NDArray[np.float32] | None = None
+        self._root: Path | None = None
+        self._cache_dir: Path | None = None
+        self._model_name: str | None = None
+        self._extensions: frozenset[str] | None = None
+        self._ignore: frozenset[str] | None = None
+        self._include_text_files: bool = False
+        self._file_state: dict[str, float] = {}
 
     def _populate_mapping(self) -> tuple[dict[str, list[int]], dict[str, list[int]]]:
         """Build (file → chunk indices, language → chunk indices) mappings, in that order."""
@@ -72,6 +85,8 @@ class SembleIndex:
         extensions: frozenset[str] | None = None,
         ignore: frozenset[str] | None = None,
         include_text_files: bool = False,
+        cache_dir: str | Path | None = None,
+        model_name: str | None = None,
     ) -> SembleIndex:
         """Create and index a SembleIndex from a directory.
 
@@ -80,10 +95,14 @@ class SembleIndex:
         :param extensions: File extensions to include. Defaults to a standard set of code extensions.
         :param ignore: Directory names to skip. Defaults to common VCS and build dirs.
         :param include_text_files: If True, also index non-code text files (.md, .yaml, .json, etc.).
+        :param cache_dir: If set, persist index to this directory after build (enables refresh).
+        :param model_name: Name of the embedding model (recorded in cache for later reload).
         :return: An indexed SembleIndex. Chunk file paths are relative to ``path``.
         :raises FileNotFoundError: If `path` does not exist.
         :raises NotADirectoryError: If `path` exists but is not a directory.
         """
+        from semble.persistence import save_index
+
         model = model or load_model()
         path = Path(path)
         if not path.exists():
@@ -100,7 +119,18 @@ class SembleIndex:
             display_root=path,
         )
 
-        index = SembleIndex(model, bm25, vicinity, chunks)
+        index = cls(model, bm25, vicinity, chunks)
+        index._embeddings = np.asarray(vicinity._vectors, dtype=np.float32)
+        index._root = path
+        index._cache_dir = Path(cache_dir) if cache_dir is not None else None
+        index._model_name = model_name
+        index._extensions = extensions
+        index._ignore = ignore
+        index._include_text_files = include_text_files
+        index._file_state = _scan_file_state(path, extensions, ignore, include_text_files)
+
+        if index._cache_dir is not None:
+            save_index(index, index._cache_dir)
 
         return index
 
@@ -150,9 +180,104 @@ class SembleIndex:
                 display_root=resolved_path,
             )
 
-            index = SembleIndex(model, bm25, vicinity, chunks)
-
+            index = cls(model, bm25, vicinity, chunks)
+            index._embeddings = np.asarray(vicinity._vectors, dtype=np.float32)
             return index
+
+    def refresh(self, changed_paths: Iterable[str | Path] | None = None) -> None:
+        """Re-index the codebase, in full or for a subset of files.
+
+        :param changed_paths: If None, perform a full rebuild. Otherwise, paths
+            (absolute or root-relative) of files added/modified/deleted since
+            the last build; only those files are re-chunked and re-embedded.
+        :raises RuntimeError: If the index has no associated root (e.g. built via from_git).
+        """
+        from semble.persistence import save_index
+
+        if self._root is None:
+            raise RuntimeError("refresh() requires an index built with a root path")
+
+        if changed_paths is None:
+            self._full_rebuild()
+        else:
+            self._incremental(changed_paths)
+
+        if self._cache_dir is not None:
+            save_index(self, self._cache_dir)
+
+    def _full_rebuild(self) -> None:
+        assert self._root is not None
+        bm25, vicinity, chunks = create_index_from_path(
+            self._root,
+            model=self.model,
+            extensions=self._extensions,
+            ignore=self._ignore,
+            include_text_files=self._include_text_files,
+            display_root=self._root,
+        )
+        self._install(bm25, vicinity, chunks, np.asarray(vicinity._vectors, dtype=np.float32))
+        self._file_state = _scan_file_state(
+            self._root, self._extensions, self._ignore, self._include_text_files
+        )
+
+    def _incremental(self, changed_paths: Iterable[str | Path]) -> None:
+        assert self._root is not None
+        rel_changed: set[str] = set()
+        for p in changed_paths:
+            rel_changed.add(_to_rel(self._root, p))
+
+        kept_pairs = [(c, i) for i, c in enumerate(self.chunks) if c.file_path not in rel_changed]
+        kept_chunks = [c for c, _ in kept_pairs]
+        kept_idx = [i for _, i in kept_pairs]
+        embeddings = self._embeddings if self._embeddings is not None else np.empty((0, 0), dtype=np.float32)
+        kept_embeddings = embeddings[kept_idx] if kept_idx else np.empty((0, embeddings.shape[1] if embeddings.ndim == 2 else 0), dtype=np.float32)
+
+        ext_set = filter_extensions(self._extensions, include_text_files=self._include_text_files)
+        new_chunks: list[Chunk] = []
+        for rel in rel_changed:
+            abs_path = (self._root / rel).resolve()
+            if not abs_path.is_file() or abs_path.suffix.lower() not in ext_set:
+                self._file_state.pop(rel, None)
+                continue
+            language = language_for_path(abs_path)
+            with contextlib.suppress(OSError):
+                source = abs_path.read_text(encoding="utf-8", errors="replace")
+                new_chunks.extend(chunk_source(source, rel, language))
+                with contextlib.suppress(OSError):
+                    self._file_state[rel] = abs_path.stat().st_mtime
+
+        new_embeddings = embed_chunks(self.model, new_chunks)
+        all_chunks = kept_chunks + new_chunks
+        if not all_chunks:
+            # Empty index: keep prior structures as-is to avoid breaking search() invariants.
+            # bm25s.BM25.index() requires at least one document; refuse to collapse.
+            raise ValueError("Refresh would leave the index empty; aborting.")
+
+        if kept_embeddings.size and new_embeddings.size:
+            all_embeddings = np.vstack([kept_embeddings, new_embeddings]).astype(np.float32, copy=False)
+        elif new_embeddings.size:
+            all_embeddings = new_embeddings.astype(np.float32, copy=False)
+        else:
+            all_embeddings = kept_embeddings.astype(np.float32, copy=False)
+
+        from semble.persistence import _build_bm25, _build_semantic
+
+        bm25 = _build_bm25(all_chunks)
+        semantic = _build_semantic(all_embeddings)
+        self._install(bm25, semantic, all_chunks, all_embeddings)
+
+    def _install(
+        self,
+        bm25: BM25,
+        semantic: SelectableBasicBackend,
+        chunks: list[Chunk],
+        embeddings: npt.NDArray[np.float32],
+    ) -> None:
+        self._bm25_index = bm25
+        self._semantic_index = semantic
+        self.chunks = chunks
+        self._embeddings = embeddings
+        self._file_mapping, self._language_mapping = self._populate_mapping()
 
     def find_related(self, source: Chunk | SearchResult, *, top_k: int = 5) -> list[SearchResult]:
         """Return chunks semantically similar to the given chunk or search result.
@@ -217,3 +342,30 @@ class SembleIndex:
                 query, self.model, semantic_index, bm25_index, self.chunks, top_k, alpha=alpha, selector=selector
             )
         raise ValueError(f"Unknown search mode: {mode!r}")
+
+
+def _to_rel(root: Path, p: str | Path) -> str:
+    """Normalize a path to a forward-slash root-relative string."""
+    pp = Path(p)
+    if pp.is_absolute():
+        try:
+            return pp.resolve().relative_to(root).as_posix()
+        except ValueError:
+            return pp.resolve().as_posix()
+    return Path(p).as_posix()
+
+
+def _scan_file_state(
+    root: Path,
+    extensions: frozenset[str] | None,
+    ignore: frozenset[str] | None,
+    include_text_files: bool,
+) -> dict[str, float]:
+    """Map root-relative posix path -> mtime for every file currently indexable."""
+    ext_set = filter_extensions(extensions, include_text_files=include_text_files)
+    state: dict[str, float] = {}
+    for fp in walk_files(root, ext_set, ignore):
+        rel = fp.relative_to(root).as_posix()
+        with contextlib.suppress(OSError):
+            state[rel] = fp.stat().st_mtime
+    return state

--- a/src/semble/mcp.py
+++ b/src/semble/mcp.py
@@ -8,7 +8,8 @@ from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 
 from semble.index import SembleIndex
-from semble.index.dense import load_model
+from semble.index.dense import _DEFAULT_MODEL_NAME, load_model
+from semble.persistence import CACHE_DIRNAME, cache_dir_for, load_index, meta_mtime
 from semble.types import Encoder
 from semble.utils import _format_results, _is_git_url, _resolve_chunk
 
@@ -101,10 +102,17 @@ def create_server(cache: _IndexCache, default_source: str | None = None) -> Fast
     return server
 
 
-async def serve(path: str | None = None, ref: str | None = None) -> None:
-    """Start an MCP stdio server, optionally pre-indexing a default source."""
+async def serve(path: str | None = None, ref: str | None = None, use_cache: bool = True) -> None:
+    """Start an MCP stdio server, optionally pre-indexing a default source.
+
+    :param path: Default source to pre-index (local dir or git URL).
+    :param ref: Branch/tag for git URLs.
+    :param use_cache: If True (default), local paths persist and reload from
+        ``<path>/.semble``; the cache reloads automatically when ``meta.json``
+        mtime advances (e.g. after ``semble reindex`` or ``semble watch``).
+    """
     model = await asyncio.to_thread(load_model)
-    cache = _IndexCache(model=model)
+    cache = _IndexCache(model=model, use_cache=use_cache)
     if path:
         await cache.get(path, ref=ref)
 
@@ -113,17 +121,33 @@ async def serve(path: str | None = None, ref: str | None = None) -> None:
 
 
 class _IndexCache:
-    """Cache of indexed repos and local paths for the lifetime of the MCP server process."""
+    """Cache of indexed repos and local paths for the lifetime of the MCP server process.
 
-    def __init__(self, model: Encoder) -> None:
+    For local paths, the index is also persisted to ``<path>/.semble`` so that
+    external refresh (git hook, file watcher) can update it. ``get()`` re-checks
+    ``meta.json`` mtime and transparently reloads when it advances.
+    """
+
+    def __init__(self, model: Encoder, use_cache: bool = True) -> None:
         """Initialise an empty cache with a shared embedding model."""
         self._model = model
+        self._use_cache = use_cache
         self._tasks: dict[str, asyncio.Task[SembleIndex]] = {}
+        self._meta_mtimes: dict[str, float] = {}
 
     async def get(self, source: str, ref: str | None = None) -> SembleIndex:
         """Return an index for the requested source, building and caching it on first access."""
         is_git = _is_git_url(source)
         cache_key = (f"{source}@{ref}" if ref else source) if is_git else str(Path(source).resolve())
+
+        if not is_git and self._use_cache:
+            cdir = cache_dir_for(Path(cache_key))
+            current = meta_mtime(cdir)
+            cached = self._meta_mtimes.get(cache_key)
+            if current is not None and cached is not None and current > cached:
+                # On-disk index has been refreshed by an external process; drop our cached task.
+                self._tasks.pop(cache_key, None)
+                self._meta_mtimes.pop(cache_key, None)
 
         if cache_key not in self._tasks:
             if is_git:
@@ -132,11 +156,11 @@ class _IndexCache:
                 )
             else:
                 self._tasks[cache_key] = asyncio.create_task(
-                    asyncio.to_thread(SembleIndex.from_path, cache_key, model=self._model)
+                    asyncio.to_thread(self._load_or_build, cache_key)
                 )
         task = self._tasks[cache_key]
         try:
-            return await asyncio.shield(task)
+            index = await asyncio.shield(task)
         except asyncio.CancelledError:  # pragma: no cover
             if task.done():
                 self._tasks.pop(cache_key, None)
@@ -145,3 +169,24 @@ class _IndexCache:
             # Build failed: evict so the next caller can retry.
             self._tasks.pop(cache_key, None)
             raise
+
+        if not is_git and self._use_cache:
+            cdir = cache_dir_for(Path(cache_key))
+            mt = meta_mtime(cdir)
+            if mt is not None:
+                self._meta_mtimes[cache_key] = mt
+        return index
+
+    def _load_or_build(self, path: str) -> SembleIndex:
+        """Load persisted index from ``path/.semble`` if present; otherwise build and persist."""
+        cdir = cache_dir_for(Path(path))
+        if self._use_cache:
+            existing = load_index(cdir, model=self._model)
+            if existing is not None:
+                return existing
+        return SembleIndex.from_path(
+            path,
+            model=self._model,
+            cache_dir=cdir if self._use_cache else None,
+            model_name=_DEFAULT_MODEL_NAME,
+        )

--- a/src/semble/persistence.py
+++ b/src/semble/persistence.py
@@ -1,0 +1,197 @@
+"""Disk persistence for SembleIndex.
+
+Layout under ``<root>/.semble/``::
+
+    chunks.jsonl    one JSON object per chunk
+    embeddings.npy  float32 array, row order matches chunks.jsonl
+    meta.json       index metadata + per-file mtime map
+
+BM25 and the vicinity backend are not persisted directly — they are rebuilt
+from chunks/embeddings on load, which is the cheap step in indexing.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import bm25s
+import numpy as np
+import numpy.typing as npt
+from vicinity.backends.basic import BasicArgs
+
+from semble.index.dense import SelectableBasicBackend
+from semble.index.sparse import enrich_for_bm25
+from semble.tokens import tokenize
+from semble.types import Chunk
+
+if TYPE_CHECKING:
+    from semble.index.index import SembleIndex
+
+CACHE_DIRNAME = ".semble"
+SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True, slots=True)
+class IndexMeta:
+    schema_version: int
+    model_name: str
+    root: str
+    extensions: list[str] | None
+    ignore: list[str] | None
+    include_text_files: bool
+    file_state: dict[str, float]  # display-relative path -> mtime
+
+
+def cache_dir_for(root: Path) -> Path:
+    """Return the .semble cache dir under root."""
+    return Path(root) / CACHE_DIRNAME
+
+
+def _chunks_path(d: Path) -> Path:
+    return d / "chunks.jsonl"
+
+
+def _embeddings_path(d: Path) -> Path:
+    return d / "embeddings.npy"
+
+
+def _meta_path(d: Path) -> Path:
+    return d / "meta.json"
+
+
+def meta_mtime(cache_dir: Path) -> float | None:
+    """Return mtime of meta.json or None if absent."""
+    p = _meta_path(cache_dir)
+    return p.stat().st_mtime if p.exists() else None
+
+
+def save_index(index: SembleIndex, cache_dir: Path) -> None:
+    """Persist chunks, embeddings, and meta to ``cache_dir``."""
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    embeddings = np.asarray(index._semantic_index._vectors, dtype=np.float32)
+    np.save(_embeddings_path(cache_dir), embeddings, allow_pickle=False)
+
+    with _chunks_path(cache_dir).open("w", encoding="utf-8") as f:
+        for c in index.chunks:
+            f.write(
+                json.dumps(
+                    {
+                        "content": c.content,
+                        "file_path": c.file_path,
+                        "start_line": c.start_line,
+                        "end_line": c.end_line,
+                        "language": c.language,
+                    },
+                    ensure_ascii=False,
+                )
+                + "\n"
+            )
+
+    meta = {
+        "schema_version": SCHEMA_VERSION,
+        "model_name": index._model_name,
+        "root": str(index._root),
+        "extensions": sorted(index._extensions) if index._extensions is not None else None,
+        "ignore": sorted(index._ignore) if index._ignore is not None else None,
+        "include_text_files": index._include_text_files,
+        "file_state": index._file_state,
+    }
+    # Atomic write so partial writes never appear newer than valid state.
+    tmp = _meta_path(cache_dir).with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(meta, indent=2), encoding="utf-8")
+    tmp.replace(_meta_path(cache_dir))
+
+
+def _load_chunks(path: Path) -> list[Chunk]:
+    chunks: list[Chunk] = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            d = json.loads(line)
+            chunks.append(
+                Chunk(
+                    content=d["content"],
+                    file_path=d["file_path"],
+                    start_line=d["start_line"],
+                    end_line=d["end_line"],
+                    language=d.get("language"),
+                )
+            )
+    return chunks
+
+
+def _build_bm25(chunks: list[Chunk]) -> bm25s.BM25:
+    bm25_index = bm25s.BM25()
+    bm25_index.index([tokenize(enrich_for_bm25(c)) for c in chunks], show_progress=False)
+    return bm25_index
+
+
+def _build_semantic(embeddings: npt.NDArray[np.float32]) -> SelectableBasicBackend:
+    return SelectableBasicBackend(embeddings, BasicArgs())
+
+
+def load_meta(cache_dir: Path) -> IndexMeta | None:
+    """Read meta.json or return None if missing/incompatible."""
+    p = _meta_path(cache_dir)
+    if not p.exists():
+        return None
+    try:
+        d = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if d.get("schema_version") != SCHEMA_VERSION:
+        return None
+    return IndexMeta(
+        schema_version=d["schema_version"],
+        model_name=d["model_name"],
+        root=d["root"],
+        extensions=d.get("extensions"),
+        ignore=d.get("ignore"),
+        include_text_files=d.get("include_text_files", False),
+        file_state=d.get("file_state", {}),
+    )
+
+
+def load_index(cache_dir: Path, model: object | None = None):  # type: ignore[no-untyped-def]
+    """Load a persisted index. Returns SembleIndex or None if cache absent/invalid.
+
+    If ``model`` is None, the model named in meta.json is loaded.
+    """
+    from semble.index.dense import load_model
+    from semble.index.index import SembleIndex
+
+    meta = load_meta(cache_dir)
+    if meta is None:
+        return None
+    chunks_p = _chunks_path(cache_dir)
+    emb_p = _embeddings_path(cache_dir)
+    if not chunks_p.exists() or not emb_p.exists():
+        return None
+
+    chunks = _load_chunks(chunks_p)
+    embeddings = np.load(emb_p, allow_pickle=False).astype(np.float32, copy=False)
+    if len(chunks) != len(embeddings):
+        return None
+
+    if model is None:
+        model = load_model(meta.model_name)
+
+    bm25_index = _build_bm25(chunks)
+    semantic_index = _build_semantic(embeddings)
+
+    index = SembleIndex(model, bm25_index, semantic_index, chunks)  # type: ignore[arg-type]
+    index._embeddings = embeddings
+    index._root = Path(meta.root)
+    index._cache_dir = cache_dir
+    index._model_name = meta.model_name
+    index._extensions = frozenset(meta.extensions) if meta.extensions is not None else None
+    index._ignore = frozenset(meta.ignore) if meta.ignore is not None else None
+    index._include_text_files = meta.include_text_files
+    index._file_state = dict(meta.file_state)
+    return index

--- a/src/semble/version.py
+++ b/src/semble/version.py
@@ -1,2 +1,2 @@
 __version_triple__ = (0, 1, 1)
-__version__ = ".".join(map(str, __version_triple__))
+__version__ = ".".join(map(str, __version_triple__)) + "+live.1"

--- a/src/semble/watch.py
+++ b/src/semble/watch.py
@@ -1,0 +1,105 @@
+"""Local file watcher: re-index changed files into ``<root>/.semble``."""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from semble.index.file_walker import DEFAULT_IGNORED_DIRS, filter_extensions
+
+if TYPE_CHECKING:
+    from semble.index.index import SembleIndex
+
+
+def watch(
+    index: SembleIndex,
+    *,
+    debounce_seconds: float = 0.5,
+    on_refresh: "callable | None" = None,  # type: ignore[name-defined]
+) -> None:
+    """Block, re-indexing on file change events. Ctrl-C to stop.
+
+    :param index: A SembleIndex with an associated root and cache_dir.
+    :param debounce_seconds: Coalesce events within this window into one refresh.
+    :param on_refresh: Optional callback ``fn(changed_paths)`` invoked after each refresh.
+    :raises RuntimeError: If ``index`` has no root, or if ``watchdog`` is not installed.
+    """
+    try:
+        from watchdog.events import FileSystemEvent, FileSystemEventHandler
+        from watchdog.observers import Observer
+    except ImportError as exc:
+        raise RuntimeError(
+            "watchdog is required for `semble watch`. Install with: pip install watchdog"
+        ) from exc
+
+    if index._root is None:
+        raise RuntimeError("watch() requires an index built from a local path")
+    root = index._root
+    ext_set = filter_extensions(index._extensions, include_text_files=index._include_text_files)
+    ignore_dirs = DEFAULT_IGNORED_DIRS | (index._ignore or frozenset())
+
+    pending: set[str] = set()
+    lock = threading.Lock()
+    timer: threading.Timer | None = None
+
+    def _is_relevant(path_str: str) -> bool:
+        try:
+            p = Path(path_str).resolve()
+            rel = p.relative_to(root)
+        except ValueError:
+            return False
+        # Skip ignored directories anywhere in path.
+        for part in rel.parts[:-1]:
+            if part in ignore_dirs:
+                return False
+        if p.suffix.lower() not in ext_set:
+            # Allow deletes of previously-indexed files even if extension filter excludes them now.
+            return rel.as_posix() in index._file_state
+        return True
+
+    def _flush() -> None:
+        nonlocal timer
+        with lock:
+            batch = list(pending)
+            pending.clear()
+            timer = None
+        if not batch:
+            return
+        try:
+            index.refresh(batch)
+        except Exception as exc:
+            print(f"[semble watch] refresh failed: {exc}")
+            return
+        if on_refresh is not None:
+            on_refresh(batch)
+        print(f"[semble watch] refreshed {len(batch)} file(s)")
+
+    class _Handler(FileSystemEventHandler):
+        def on_any_event(self, event: FileSystemEvent) -> None:
+            nonlocal timer
+            if event.is_directory:
+                return
+            if not _is_relevant(event.src_path):
+                return
+            with lock:
+                pending.add(str(Path(event.src_path).resolve()))
+                if timer is not None:
+                    timer.cancel()
+                timer = threading.Timer(debounce_seconds, _flush)
+                timer.daemon = True
+                timer.start()
+
+    observer = Observer()
+    observer.schedule(_Handler(), str(root), recursive=True)
+    observer.start()
+    print(f"[semble watch] watching {root} (Ctrl-C to stop)")
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        observer.stop()
+        observer.join()


### PR DESCRIPTION
Make semble re-index local code when it changes, so MCP/CLI search reflects the current state without server restart.

- src/semble/persistence.py: save/load chunks, embeddings, meta to <root>/.semble. BM25 + vicinity backend rebuilt on load (the cheap step in indexing).
- src/semble/index/index.py: SembleIndex.refresh(changed_paths=None) for full or incremental rebuild; from_path now accepts cache_dir to enable persistence.
- src/semble/mcp.py: _IndexCache loads from disk when present and reloads when meta.json mtime advances, so external refresh (hook/watcher) is picked up.
- src/semble/hooks.py: install/uninstall a semble-managed post-commit hook.
- src/semble/watch.py: watchdog-backed file watcher with debounced refresh.
- src/semble/cli.py: new commands reindex, watch, install-hooks, uninstall-hooks.
- pyproject.toml: add watchdog dependency, version bump to 0.1.1+live.1.