### PR TITLE
fix: Pin tree-sitter-language-pack

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "bm25s>=0.2.0",
     "pathspec>=0.12",
     "tree-sitter>=0.25",
-    "tree-sitter-language-pack!=1.6.3"
+    "tree-sitter-language-pack>=1.0,<1.8.0,!=1.6.3"
 ]
 
 [project.optional-dependencies]
@@ -144,4 +144,3 @@ exclude_also = ["if __name__ == .__main__.:", "@abstractmethod"]
 
 [tool.uv]
 exclude-newer = "1 week"
-constraint-dependencies = ["tree-sitter-language-pack!=1.6.3"] # no MacOS wheels

--- a/src/semble/version.py
+++ b/src/semble/version.py
@@ -1,2 +1,2 @@
-__version_triple__ = (0, 1, 4)
+__version_triple__ = (0, 1, 5)
 __version__ = ".".join(map(str, __version_triple__))

--- a/uv.lock
+++ b/uv.lock
@@ -11,11 +11,11 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-07T14:45:29.536086Z"
-exclude-newer-span = "P3D"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P1W"
 
 [manifest]
-constraints = [{ name = "tree-sitter-language-pack", specifier = "!=1.6.3" }]
+constraints = [{ name = "tree-sitter-language-pack", specifier = ">=1.0,!=1.6.3,<1.8.0" }]
 
 [[package]]
 name = "annotated-doc"
@@ -3148,7 +3148,7 @@ requires-dist = [
     { name = "sentence-transformers", marker = "extra == 'benchmark'", specifier = ">=3.0" },
     { name = "tiktoken", marker = "extra == 'benchmark'", specifier = ">=0.7" },
     { name = "tree-sitter", specifier = ">=0.25" },
-    { name = "tree-sitter-language-pack", specifier = "!=1.6.3" },
+    { name = "tree-sitter-language-pack", specifier = ">=1.0,!=1.6.3,<1.8.0" },
     { name = "vicinity", specifier = ">=0.4.4" },
     { name = "watchfiles", marker = "extra == 'mcp'", specifier = ">=0.21" },
 ]


### PR DESCRIPTION
tree-sitter-language-pack has a major API break in 1.8.0. See https://github.com/MinishLab/semble/issues/86. This PR pins it.