### PR TITLE
fix: Make allowlist-style .gitignore work properly with pathspec

### DIFF
--- a/src/semble/index/file_walker.py
+++ b/src/semble/index/file_walker.py
@@ -99,21 +99,35 @@ def filter_extensions(extensions: frozenset[str] | None, *, include_text_files: 
     return frozenset(ext for ext, spec in FILE_TYPES.items() if spec.category in categories_to_include)
 
 
-def _load_root_gitignore(root: Path) -> tuple[GitIgnoreSpec | None, GitIgnoreSpec | None]:
-    """Load root .gitignore and return (file_spec, dir_spec).
+def _load_root_gitignore(root: Path) -> tuple[list[tuple[bool, GitIgnoreSpec]], GitIgnoreSpec | None]:
+    """Load root .gitignore, returning (dir_patterns, file_spec).
 
-    dir_spec is built only from patterns that explicitly target directories
-    (lines ending with /), which are safe to use for directory pruning.
-    file_spec covers all patterns and is used for per-file filtering.
+    dir_patterns is a list of (is_negation, per-pattern spec) in gitignore order,
+    used for last-match-wins directory pruning that correctly handles negations.
+    file_spec is the full combined spec for per-file filtering.
     """
     gitignore = root / ".gitignore"
     if not gitignore.is_file():
-        return None, None
+        return [], None
     lines = gitignore.read_text(encoding="utf-8", errors="ignore").splitlines()
-    file_spec = GitIgnoreSpec.from_lines(lines)
-    dir_lines = [ln for ln in lines if ln.rstrip().endswith("/")]
-    dir_spec = GitIgnoreSpec.from_lines(dir_lines) if dir_lines else None
-    return file_spec, dir_spec
+    dir_patterns: list[tuple[bool, GitIgnoreSpec]] = []
+    for line in lines:
+        stripped = line.rstrip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        negate = stripped.startswith("!")
+        pattern = stripped[1:] if negate else stripped
+        dir_patterns.append((negate, GitIgnoreSpec.from_lines([pattern])))
+    return dir_patterns, GitIgnoreSpec.from_lines(lines)
+
+
+def _dir_is_gitignored(dir_patterns: list[tuple[bool, GitIgnoreSpec]], rel_dir: str) -> bool:
+    """Return True if this directory path is gitignored using last-match-wins semantics."""
+    result = False
+    for negate, spec in dir_patterns:
+        if spec.match_file(rel_dir):
+            result = not negate
+    return result
 
 
 def walk_files(root: Path, extensions: frozenset[str], ignore: frozenset[str] | None = None) -> Iterator[Path]:
@@ -129,20 +143,16 @@ def walk_files(root: Path, extensions: frozenset[str], ignore: frozenset[str] | 
     :ytype: Path
     """
     ignore_dirs = DEFAULT_IGNORED_DIRS | (ignore or frozenset())
-    file_gitignore, dir_gitignore = _load_root_gitignore(root)
+    dir_patterns, file_gitignore = _load_root_gitignore(root)
     for dirpath, dirnames, filenames in os.walk(root):
         rel_dir = Path(dirpath).relative_to(root)
-        # Prune in-place so os.walk doesn't descend into ignored trees.
-        # Only use dir_gitignore (patterns ending with /) for directory pruning:
-        # pathspec misreports directories as matched under allowlist-style patterns
-        # like `*` + `!*/`, so we restrict to unambiguous directory-only patterns.
         kept: list[str] = []
         for dirname in dirnames:
             if dirname in ignore_dirs:
                 continue
-            if dir_gitignore is not None:
+            if dir_patterns:
                 rel = (rel_dir / dirname).as_posix() + "/"
-                if dir_gitignore.match_file(rel):
+                if _dir_is_gitignored(dir_patterns, rel):
                     continue
             kept.append(dirname)
         dirnames[:] = kept

--- a/src/semble/index/file_walker.py
+++ b/src/semble/index/file_walker.py
@@ -124,16 +124,12 @@ def walk_files(root: Path, extensions: frozenset[str], ignore: frozenset[str] | 
     gitignore = _load_root_gitignore(root)
     for dirpath, dirnames, filenames in os.walk(root):
         rel_dir = Path(dirpath).relative_to(root)
-        # Prune in-place so os.walk doesn't descend into ignored trees.
-        kept: list[str] = []
-        for dirname in dirnames:
-            if dirname in ignore_dirs:
-                continue
-            rel = (rel_dir / dirname).as_posix() + "/"
-            if gitignore is not None and gitignore.match_file(rel):
-                continue
-            kept.append(dirname)
-        dirnames[:] = kept
+        # Prune in-place so os.walk skips known build/tool dirs.
+        # We do not use gitignore here as pathspec misreports directories as matched
+        # under allowlist-style patterns (e.g. `*` + `!*/`), which would prune
+        # subdirectories whose contents should still be indexed. File-level
+        # filtering below is always correct.
+        dirnames[:] = [d for d in dirnames if d not in ignore_dirs]
         for filename in sorted(filenames):
             file_path = Path(dirpath) / filename
             if file_path.suffix.lower() not in extensions:

--- a/src/semble/index/file_walker.py
+++ b/src/semble/index/file_walker.py
@@ -99,13 +99,21 @@ def filter_extensions(extensions: frozenset[str] | None, *, include_text_files: 
     return frozenset(ext for ext, spec in FILE_TYPES.items() if spec.category in categories_to_include)
 
 
-def _load_root_gitignore(root: Path) -> GitIgnoreSpec | None:
-    """Load the root-level .gitignore as a spec, if present."""
+def _load_root_gitignore(root: Path) -> tuple[GitIgnoreSpec | None, GitIgnoreSpec | None]:
+    """Load root .gitignore and return (file_spec, dir_spec).
+
+    dir_spec is built only from patterns that explicitly target directories
+    (lines ending with /), which are safe to use for directory pruning.
+    file_spec covers all patterns and is used for per-file filtering.
+    """
     gitignore = root / ".gitignore"
     if not gitignore.is_file():
-        return None
-    with gitignore.open("r", encoding="utf-8", errors="ignore") as f:
-        return GitIgnoreSpec.from_lines(f)
+        return None, None
+    lines = gitignore.read_text(encoding="utf-8", errors="ignore").splitlines()
+    file_spec = GitIgnoreSpec.from_lines(lines)
+    dir_lines = [ln for ln in lines if ln.rstrip().endswith("/")]
+    dir_spec = GitIgnoreSpec.from_lines(dir_lines) if dir_lines else None
+    return file_spec, dir_spec
 
 
 def walk_files(root: Path, extensions: frozenset[str], ignore: frozenset[str] | None = None) -> Iterator[Path]:
@@ -121,21 +129,29 @@ def walk_files(root: Path, extensions: frozenset[str], ignore: frozenset[str] | 
     :ytype: Path
     """
     ignore_dirs = DEFAULT_IGNORED_DIRS | (ignore or frozenset())
-    gitignore = _load_root_gitignore(root)
+    file_gitignore, dir_gitignore = _load_root_gitignore(root)
     for dirpath, dirnames, filenames in os.walk(root):
         rel_dir = Path(dirpath).relative_to(root)
-        # Prune in-place so os.walk skips known build/tool dirs.
-        # We do not use gitignore here as pathspec misreports directories as matched
-        # under allowlist-style patterns (e.g. `*` + `!*/`), which would prune
-        # subdirectories whose contents should still be indexed. File-level
-        # filtering below is always correct.
-        dirnames[:] = [d for d in dirnames if d not in ignore_dirs]
+        # Prune in-place so os.walk doesn't descend into ignored trees.
+        # Only use dir_gitignore (patterns ending with /) for directory pruning:
+        # pathspec misreports directories as matched under allowlist-style patterns
+        # like `*` + `!*/`, so we restrict to unambiguous directory-only patterns.
+        kept: list[str] = []
+        for dirname in dirnames:
+            if dirname in ignore_dirs:
+                continue
+            if dir_gitignore is not None:
+                rel = (rel_dir / dirname).as_posix() + "/"
+                if dir_gitignore.match_file(rel):
+                    continue
+            kept.append(dirname)
+        dirnames[:] = kept
         for filename in sorted(filenames):
             file_path = Path(dirpath) / filename
             if file_path.suffix.lower() not in extensions:
                 continue
-            if gitignore is not None:
+            if file_gitignore is not None:
                 rel_file = (rel_dir / filename).as_posix()
-                if gitignore.match_file(rel_file):
+                if file_gitignore.match_file(rel_file):
                     continue
             yield file_path

--- a/src/semble/index/file_walker.py
+++ b/src/semble/index/file_walker.py
@@ -99,25 +99,21 @@ def filter_extensions(extensions: frozenset[str] | None, *, include_text_files: 
     return frozenset(ext for ext, spec in FILE_TYPES.items() if spec.category in categories_to_include)
 
 
-def _load_root_gitignore(root: Path) -> tuple[list[tuple[bool, GitIgnoreSpec]], GitIgnoreSpec | None]:
-    """Load root .gitignore, returning (dir_patterns, file_spec).
-
-    dir_patterns enables last-match-wins directory pruning that correctly handles
-    allowlist-style gitignores (e.g. `*` + `!*/`). file_spec is used for per-file
-    filtering where pathspec's combined match_file is correct.
-    """
+def _load_root_gitignore(root: Path) -> GitIgnoreSpec | None:
+    """Load the root-level .gitignore as a spec, if present."""
     gitignore = root / ".gitignore"
     if not gitignore.is_file():
-        return [], None
-    lines = gitignore.read_text(encoding="utf-8", errors="ignore").splitlines()
-    patterns: list[tuple[bool, GitIgnoreSpec]] = []
-    for line in lines:
-        s = line.rstrip()
-        if not s or s.startswith("#"):
-            continue
-        neg = s.startswith("!")
-        patterns.append((neg, GitIgnoreSpec.from_lines([s[1:] if neg else s])))
-    return patterns, GitIgnoreSpec.from_lines(lines)
+        return None
+    return GitIgnoreSpec.from_lines(gitignore.read_text(encoding="utf-8", errors="ignore").splitlines())
+
+
+def _dir_is_gitignored(gitignore: GitIgnoreSpec, rel: str) -> bool:
+    """Return True if rel (a POSIX path relative to the gitignore root) matches a gitignore pattern for directories."""
+    ignored = False
+    for pattern in gitignore.patterns:
+        if pattern.include is not None and pattern.match_file(rel):
+            ignored = pattern.include
+    return ignored
 
 
 def walk_files(root: Path, extensions: frozenset[str], ignore: frozenset[str] | None = None) -> Iterator[Path]:
@@ -133,25 +129,21 @@ def walk_files(root: Path, extensions: frozenset[str], ignore: frozenset[str] | 
     :ytype: Path
     """
     ignore_dirs = DEFAULT_IGNORED_DIRS | (ignore or frozenset())
-    dir_patterns, file_spec = _load_root_gitignore(root)
+    gitignore = _load_root_gitignore(root)
     for dirpath, dirnames, filenames in os.walk(root):
         rel_dir = Path(dirpath).relative_to(root)
         kept: list[str] = []
         for dirname in dirnames:
             if dirname in ignore_dirs:
                 continue
-            rel = (rel_dir / dirname).as_posix() + "/"
-            ignored = False
-            for neg, spec in dir_patterns:
-                if spec.match_file(rel):
-                    ignored = not neg
-            if not ignored:
-                kept.append(dirname)
+            if gitignore is not None and _dir_is_gitignored(gitignore, (rel_dir / dirname).as_posix() + "/"):
+                continue
+            kept.append(dirname)
         dirnames[:] = kept
         for filename in sorted(filenames):
             file_path = Path(dirpath) / filename
             if file_path.suffix.lower() not in extensions:
                 continue
-            if file_spec is not None and file_spec.match_file((rel_dir / filename).as_posix()):
+            if gitignore is not None and gitignore.match_file((rel_dir / filename).as_posix()):
                 continue
             yield file_path

--- a/src/semble/index/file_walker.py
+++ b/src/semble/index/file_walker.py
@@ -102,32 +102,22 @@ def filter_extensions(extensions: frozenset[str] | None, *, include_text_files: 
 def _load_root_gitignore(root: Path) -> tuple[list[tuple[bool, GitIgnoreSpec]], GitIgnoreSpec | None]:
     """Load root .gitignore, returning (dir_patterns, file_spec).
 
-    dir_patterns is a list of (is_negation, per-pattern spec) in gitignore order,
-    used for last-match-wins directory pruning that correctly handles negations.
-    file_spec is the full combined spec for per-file filtering.
+    dir_patterns enables last-match-wins directory pruning that correctly handles
+    allowlist-style gitignores (e.g. `*` + `!*/`). file_spec is used for per-file
+    filtering where pathspec's combined match_file is correct.
     """
     gitignore = root / ".gitignore"
     if not gitignore.is_file():
         return [], None
     lines = gitignore.read_text(encoding="utf-8", errors="ignore").splitlines()
-    dir_patterns: list[tuple[bool, GitIgnoreSpec]] = []
+    patterns: list[tuple[bool, GitIgnoreSpec]] = []
     for line in lines:
-        stripped = line.rstrip()
-        if not stripped or stripped.startswith("#"):
+        s = line.rstrip()
+        if not s or s.startswith("#"):
             continue
-        negate = stripped.startswith("!")
-        pattern = stripped[1:] if negate else stripped
-        dir_patterns.append((negate, GitIgnoreSpec.from_lines([pattern])))
-    return dir_patterns, GitIgnoreSpec.from_lines(lines)
-
-
-def _dir_is_gitignored(dir_patterns: list[tuple[bool, GitIgnoreSpec]], rel_dir: str) -> bool:
-    """Return True if this directory path is gitignored using last-match-wins semantics."""
-    result = False
-    for negate, spec in dir_patterns:
-        if spec.match_file(rel_dir):
-            result = not negate
-    return result
+        neg = s.startswith("!")
+        patterns.append((neg, GitIgnoreSpec.from_lines([s[1:] if neg else s])))
+    return patterns, GitIgnoreSpec.from_lines(lines)
 
 
 def walk_files(root: Path, extensions: frozenset[str], ignore: frozenset[str] | None = None) -> Iterator[Path]:
@@ -143,25 +133,25 @@ def walk_files(root: Path, extensions: frozenset[str], ignore: frozenset[str] | 
     :ytype: Path
     """
     ignore_dirs = DEFAULT_IGNORED_DIRS | (ignore or frozenset())
-    dir_patterns, file_gitignore = _load_root_gitignore(root)
+    dir_patterns, file_spec = _load_root_gitignore(root)
     for dirpath, dirnames, filenames in os.walk(root):
         rel_dir = Path(dirpath).relative_to(root)
         kept: list[str] = []
         for dirname in dirnames:
             if dirname in ignore_dirs:
                 continue
-            if dir_patterns:
-                rel = (rel_dir / dirname).as_posix() + "/"
-                if _dir_is_gitignored(dir_patterns, rel):
-                    continue
-            kept.append(dirname)
+            rel = (rel_dir / dirname).as_posix() + "/"
+            ignored = False
+            for neg, spec in dir_patterns:
+                if spec.match_file(rel):
+                    ignored = not neg
+            if not ignored:
+                kept.append(dirname)
         dirnames[:] = kept
         for filename in sorted(filenames):
             file_path = Path(dirpath) / filename
             if file_path.suffix.lower() not in extensions:
                 continue
-            if file_gitignore is not None:
-                rel_file = (rel_dir / filename).as_posix()
-                if file_gitignore.match_file(rel_file):
-                    continue
+            if file_spec is not None and file_spec.match_file((rel_dir / filename).as_posix()):
+                continue
             yield file_path

--- a/tests/test_file_walker.py
+++ b/tests/test_file_walker.py
@@ -41,6 +41,12 @@ def _touch(path: Path, content: str = "x = 1\n") -> None:
             "out/*\n!out/keep.py\n",
             {"out/keep.py"},
         ),
+        # Allow-list style gitignore (`*` + `!*/` + `!*.py`) must not prune subdirs.
+        (
+            ["main.py", "internal/pkg/foo.py", "internal/pkg/bar.py"],
+            "*\n!*/\n!*.py\n",
+            {"main.py", "internal/pkg/foo.py", "internal/pkg/bar.py"},
+        ),
     ],
 )
 def test_walk_files_filtering(tmp_path: Path, files: list[str], gitignore: str | None, expected: set[str]) -> None:

--- a/tests/test_file_walker.py
+++ b/tests/test_file_walker.py
@@ -47,6 +47,12 @@ def _touch(path: Path, content: str = "x = 1\n") -> None:
             "*\n!*/\n!*.py\n",
             {"main.py", "internal/pkg/foo.py", "internal/pkg/bar.py"},
         ),
+        # Ignored-parent negation: out/* prunes out/deep/, so out/deep/keep.py must not leak.
+        (
+            ["out/deep/keep.py"],
+            "out/*\n!out/deep/keep.py\n",
+            set(),
+        ),
     ],
 )
 def test_walk_files_filtering(tmp_path: Path, files: list[str], gitignore: str | None, expected: set[str]) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -14,9 +14,6 @@ resolution-markers = [
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P1W"
 
-[manifest]
-constraints = [{ name = "tree-sitter-language-pack", specifier = ">=1.0,!=1.6.3,<1.8.0" }]
-
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"

--- a/uv.lock
+++ b/uv.lock
@@ -14,6 +14,9 @@ resolution-markers = [
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P1W"
 
+[manifest]
+constraints = [{ name = "tree-sitter-language-pack", specifier = ">=1.0,!=1.6.3,<1.8.0" }]
+
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"


### PR DESCRIPTION
`walk_files` used pathspec's match_file to prune directories. This breaks allowlist-style .gitignore files (e.g. the GitHub Go template: * + !*/ + !*.go), as seen in this issue https://github.com/MinishLab/semble/issues/88. pathspec incorrectly reports directories like cmd/ and internal/ as ignored even though !*/ should un-ignore them, which causes only root-level files to be indexed.

This PR fixes that by applying patterns one at a time for directory pruning. This correctly handles both allowlist patterns and standard deny patterns. File-level filtering still uses pathspec's match_file, which does work correctly.