### PR TITLE
fix: Fix savings aggregation

### DIFF
--- a/src/semble/stats.py
+++ b/src/semble/stats.py
@@ -17,12 +17,14 @@ class BucketStats:
     calls: int = 0
     snippet_chars: int = 0
     file_chars: int = 0
+    saved_chars: int = 0
 
     def add(self, snippet_chars: int, file_chars: int) -> None:
         """Update stats with a call and its character counts."""
         self.calls += 1
         self.snippet_chars += snippet_chars
         self.file_chars += file_chars
+        self.saved_chars += max(0, file_chars - snippet_chars)
 
 
 @dataclass
@@ -113,8 +115,7 @@ def format_savings_report(path: Path | None = None, *, verbose: bool = False) ->
         light_line,
     ]
     for label, bucket in summary.buckets.items():
-        saved_chars = max(0, bucket.file_chars - bucket.snippet_chars)
-        saved_tokens = saved_chars // 4  # standard ~4 chars/token approximation
+        saved_tokens = bucket.saved_chars // 4  # standard ~4 chars/token approximation
         if saved_tokens >= 1_000_000:
             saved_str = f"~{saved_tokens / 1_000_000:.1f}M"
         elif saved_tokens >= 1000:
@@ -123,7 +124,7 @@ def format_savings_report(path: Path | None = None, *, verbose: bool = False) ->
             saved_str = f"~{saved_tokens}"
         calls_str = f"{bucket.calls / 1000:.1f}k" if bucket.calls >= 1000 else str(bucket.calls)
         if bucket.file_chars > 0:
-            ratio = saved_chars / bucket.file_chars
+            ratio = bucket.saved_chars / bucket.file_chars
             filled = round(ratio * bar_width)
             bar = "█" * filled + "░" * (bar_width - filled)
             pct = round(ratio * 100)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -72,6 +72,22 @@ def test_savings_output_millions(tmp_path: Path) -> None:
     assert "M tokens" in format_savings_report(path=stats_file)
 
 
+def test_savings_do_not_subtract_unknown_baselines(tmp_path: Path) -> None:
+    """Rows without a full-file baseline must not cancel out real savings."""
+    stats_file = tmp_path / "stats.jsonl"
+    now = datetime.now(timezone.utc).timestamp()
+    stats_file.write_text(
+        _make_stats_record(now, snippet_chars=100, file_chars=500)
+        + "\n"
+        + _make_stats_record(now, snippet_chars=1_000, file_chars=0)
+        + "\n"
+    )
+
+    summary = build_savings_summary(path=stats_file)
+    assert summary.buckets["All time"].saved_chars == 400
+    assert "~100 tokens" in format_savings_report(path=stats_file)
+
+
 def test_savings_tolerates_bad_json(tmp_path: Path) -> None:
     """Malformed JSON lines are skipped with a warning."""
     stats_file = tmp_path / "stats.jsonl"


### PR DESCRIPTION
semble savings` summed `file_chars - snippet_chars` across a whole period and clamped only at the end. Rows with `file_chars: 0` could therefore erase valid savings from other calls. This now clamps savings per call before aggregating.