### PR TITLE
feat: disable multi processing

### DIFF
--- a/src/semble/index/dense.py
+++ b/src/semble/index/dense.py
@@ -27,8 +27,8 @@ def load_model(model_path: str | None = None) -> Encoder:
 def embed_chunks(model: Encoder, chunks: list[Chunk]) -> npt.NDArray[np.float32]:
     """Embed chunks using the configured model."""
     if not chunks:
-        return np.empty((0, 256), dtype=np.float32)
-    return np.array(model.encode([c.content for c in chunks]), dtype=np.float32)
+        return np.empty((0, model.dim), dtype=np.float32)
+    return np.array(model.encode([c.content for c in chunks], use_multiprocessing=False), dtype=np.float32)
 
 
 class SelectableBasicBackend(CosineBasicBackend):

--- a/src/semble/types.py
+++ b/src/semble/types.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Protocol, TypeAlias
+from typing import Any, Protocol, TypeAlias
 
 import numpy as np
 import numpy.typing as npt
@@ -27,7 +27,12 @@ class CallType(str, Enum):
 class Encoder(Protocol):
     """Protocol for embedding models."""
 
-    def encode(self, texts: Sequence[str], /) -> EmbeddingMatrix:
+    @property
+    def dim(self) -> int:
+        """The dimensionality of the embedding."""
+        ...
+
+    def encode(self, texts: Sequence[str], /, **kwargs: Any) -> EmbeddingMatrix:
         """Encode texts into embeddings as a 2D float32 array."""
         ...  # pragma: no cover
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,5 +86,5 @@ def mock_model() -> MagicMock:
         return normalized
 
     model.encode.side_effect = _encode
-    model.dim.side_effect = lambda: _dim
+    model.dim = _dim
     return model

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import textwrap
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -76,12 +77,14 @@ def mock_model() -> MagicMock:
     """A model stub that returns deterministic random embeddings."""
     model = MagicMock()
     rng = np.random.default_rng(42)
+    _dim = 256
 
-    def _encode(texts: list[str]) -> npt.NDArray[np.float32]:
-        embs = rng.standard_normal((len(texts), 256)).astype(np.float32)
+    def _encode(texts: list[str], **kwargs: Any) -> npt.NDArray[np.float32]:
+        embs = rng.standard_normal((len(texts), _dim)).astype(np.float32)
         norms = np.linalg.norm(embs, axis=1, keepdims=True)
         normalized: npt.NDArray[np.float32] = embs / (norms + 1e-8)
         return normalized
 
     model.encode.side_effect = _encode
+    model.dim.side_effect = lambda: _dim
     return model

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -151,7 +151,7 @@ def test_load_model(model_path: str | None, expected_call_arg: str) -> None:
 def test_embed_chunks_empty_returns_empty_array(mock_model: Any) -> None:
     """embed_chunks with an empty list returns a (0, 256) float32 array."""
     result = embed_chunks(mock_model, [])
-    assert result.shape == (0, 256)
+    assert result.shape == (0, 1)
     assert result.dtype == np.float32
 
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -151,7 +151,7 @@ def test_load_model(model_path: str | None, expected_call_arg: str) -> None:
 def test_embed_chunks_empty_returns_empty_array(mock_model: Any) -> None:
     """embed_chunks with an empty list returns a (0, 256) float32 array."""
     result = embed_chunks(mock_model, [])
-    assert result.shape == (0, 1)
+    assert result.shape == (0, 256)
     assert result.dtype == np.float32
 
 


### PR DESCRIPTION
This PR disables multiprocessing. This makes indexing slightly slower (about 8% on average on our benchmark). However, we believe that #78 is caused by multiprocessing running in an async loop. Given that we don't have a good way to reproduce this issue on Windows machines (it does not happen in CI), this is a safe way to go about it.

This PR also fixes some typing stuff, where we were assuming that the dimensionality of our model was always fixed to 256. This is not true, and would (maybe) block our users from using custom models.