### PR TITLE
feat: remove tree sitter language manifest

### DIFF
--- a/src/semble/chunking/core.py
+++ b/src/semble/chunking/core.py
@@ -5,17 +5,16 @@ from functools import cache
 from logging import getLogger
 
 from tree_sitter import Node, Parser
-from tree_sitter_language_pack import SupportedLanguage, get_parser, manifest_languages
+from tree_sitter_language_pack import SupportedLanguage, get_parser
+
+from semble.index.files import ALL_LANGUAGES
 
 logger = getLogger(__name__)
 
 
-_TREE_SITTER_LANGUAGES: frozenset[str] = frozenset(manifest_languages())
-
-
 def is_supported_language(language: str) -> bool:
     """Check if the language is supported by tree-sitter."""
-    return language in _TREE_SITTER_LANGUAGES
+    return language in ALL_LANGUAGES
 
 
 @dataclass

--- a/src/semble/index/files.py
+++ b/src/semble/index/files.py
@@ -437,8 +437,8 @@ def _inv_mapping(mapping: dict[str, str]) -> dict[str, list[str]]:
     return dict(inv)
 
 
-_ALL_LANGUAGES = frozenset(_EXTENSION_TO_LANGUAGE.values())
-_WITHOUT_DOC = _ALL_LANGUAGES - _DOC_LANGUAGES
+ALL_LANGUAGES = frozenset(_EXTENSION_TO_LANGUAGE.values())
+_WITHOUT_DOC = ALL_LANGUAGES - _DOC_LANGUAGES
 _LANGUAGE_TO_EXTENSION = _inv_mapping(_EXTENSION_TO_LANGUAGE)
 
 
@@ -450,7 +450,7 @@ def detect_language(file_name: Path) -> str | None:
 def get_extensions(include_text_files: bool, extensions: Sequence[str] | None) -> list[str]:
     """Returns a list of supported file extensions."""
     if include_text_files:
-        languages = _ALL_LANGUAGES
+        languages = ALL_LANGUAGES
     else:
         languages = _WITHOUT_DOC
     all_extensions: set[str] = set()


### PR DESCRIPTION
This PR removes our reliance on tree sitter language pack for identifying which languages we support. Since we already pull out all languages from the language pack, we can simply refer to this variable, and remove the import dependency.

This is a partial solution #94. To fully solve this issue, we also need to be able to fall back from using the chunker if we detect that we can't access tree-sitter.