### PR TITLE
fix: pre-commit mypy hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,8 +30,12 @@ repos:
       - id: ruff-check
         args: [--fix]
       - id: ruff-format
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.15.0
+  - repo: local
     hooks:
       - id: mypy
-        additional_dependencies: []
+        name: mypy
+        entry: uv run --frozen mypy
+        language: system
+        types: [python]
+        pass_filenames: false
+        args: [src/]

--- a/src/semble/index/dense.py
+++ b/src/semble/index/dense.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 import numpy as np
 import numpy.typing as npt
 from huggingface_hub.utils.tqdm import disable_progress_bars
@@ -21,7 +23,7 @@ def load_model(model_path: str | None = None) -> Encoder:
         model = StaticModel.from_pretrained(model_path)
     finally:
         disable_progress_bars()
-    return model
+    return cast(Encoder, model)
 
 
 def embed_chunks(model: Encoder, chunks: list[Chunk]) -> npt.NDArray[np.float32]:

--- a/src/semble/index/file_walker.py
+++ b/src/semble/index/file_walker.py
@@ -98,8 +98,8 @@ def _is_ignored(path: Path, specs: list[IgnoreSpec]) -> tuple[bool, bool]:
                 # extension suffix (e.g. !special.kjs, !*.py). Patterns without
                 # a suffix (e.g. !vendor/, !.github/*) target directories or
                 # broad globs and should not bypass extension filtering.
-                pat = pattern.pattern or ""
-                found = not ignored and bool(Path(pat.rstrip("/")).suffix)
+                pat = pattern.pattern
+                found = not ignored and isinstance(pat, str) and bool(Path(pat.rstrip("/")).suffix)
 
     return ignored, found
 


### PR DESCRIPTION
This PR switches mypy pre-commit hook from the remote mirror to a local uv run --frozen mypy hook so it actually catches type errors and fixes two type issues that were raised.