### PR TITLE
feat: fall back to line chunking when parsing unavailable

### DIFF
--- a/src/semble/chunking/chunking.py
+++ b/src/semble/chunking/chunking.py
@@ -14,9 +14,12 @@ def chunk_source(source: str, file_path: str, language: str | None) -> list[Chun
     """Chunk pre-read source text."""
     if not source.strip():
         return []
+    chunk_boundaries = None
     if language is not None and is_supported_language(language):
         chunk_boundaries = chunk(source, language, _DESIRED_CHUNK_LENGTH_CHARS)
-    else:
+    # This is an if because the error state of the parser above
+    # is a None.
+    if chunk_boundaries is None:
         chunk_boundaries = chunk_lines(source, _DESIRED_CHUNK_LENGTH_CHARS)
 
     chunks: list[Chunk] = []

--- a/src/semble/chunking/core.py
+++ b/src/semble/chunking/core.py
@@ -5,7 +5,7 @@ from functools import cache
 from logging import getLogger
 
 from tree_sitter import Node, Parser
-from tree_sitter_language_pack import LanguageNotFoundError, SupportedLanguage, get_parser
+from tree_sitter_language_pack import DownloadError, LanguageNotFoundError, SupportedLanguage, get_parser
 
 from semble.index.files import ALL_LANGUAGES
 
@@ -32,6 +32,10 @@ def _cached_get_parser(language: SupportedLanguage) -> Parser | None:
         return get_parser(language)
     except LanguageNotFoundError:
         logger.warning("Language %s not found, falling back to line chunking", language)
+    except DownloadError:
+        logger.warning("Failed to download language %s, falling back to line chunking", language)
+    except Exception:
+        logger.error("Uncaught exception in _cached_get_parser", exc_info=True)
     return None
 
 

--- a/src/semble/chunking/core.py
+++ b/src/semble/chunking/core.py
@@ -5,7 +5,7 @@ from functools import cache
 from logging import getLogger
 
 from tree_sitter import Node, Parser
-from tree_sitter_language_pack import SupportedLanguage, get_parser
+from tree_sitter_language_pack import LanguageNotFoundError, SupportedLanguage, get_parser
 
 from semble.index.files import ALL_LANGUAGES
 
@@ -26,9 +26,13 @@ class ChunkBoundary:
 
 
 @cache
-def _cached_get_parser(language: SupportedLanguage) -> Parser:
+def _cached_get_parser(language: SupportedLanguage) -> Parser | None:
     """Gets a parser from tree_sitter."""
-    return get_parser(language)
+    try:
+        return get_parser(language)
+    except LanguageNotFoundError:
+        logger.warning("Language %s not found, falling back to line chunking", language)
+    return None
 
 
 def _merge_adjacent_chunks(
@@ -121,13 +125,15 @@ def chunk_lines(text: str, desired_length: int) -> list[ChunkBoundary]:
     return _merge_adjacent_chunks(lines_as_groups, desired_length)
 
 
-def chunk(text: str, language: str, desired_length: int) -> list[ChunkBoundary]:
+def chunk(text: str, language: str, desired_length: int) -> list[ChunkBoundary] | None:
     """Chunk source code."""
     if not text.strip():
         return []
 
     as_bytes = text.encode("utf-8")
     parser = _cached_get_parser(language)
+    if parser is None:
+        return None
     root = parser.parse(as_bytes).root_node
 
     chunks = []

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -1,7 +1,10 @@
+import logging
 from unittest.mock import patch
 
+import pytest
+
 from semble.chunking.chunking import Chunk, chunk_lines, chunk_source
-from semble.chunking.core import ChunkBoundary, chunk
+from semble.chunking.core import ChunkBoundary, _cached_get_parser, chunk
 
 
 def test_chunk_lines() -> None:
@@ -53,6 +56,7 @@ def test_core_chunk_recursive_split_and_break() -> None:
     """core.chunk recursively splits large nodes and breaks when siblings exceed the limit."""
     code = "x = 1\ndef foo():\n    a = 1\n    b = 2\n    c = 3\ny = 2\n"
     chunks = chunk(code, "python", 10)
+    assert chunks is not None
     assert len(chunks) >= 3
     assert chunks[0].start == 0
     # Non-overlapping and within bounds
@@ -69,7 +73,28 @@ def test_core_chunk_leaf_node_exceeds_desired_length() -> None:
     long_var = "x" * 100
     code = f"{long_var} = 1\n"
     chunks = chunk(code, "python", 50)
+    assert chunks is not None
     assert len(chunks) >= 1
     assert chunks[0].start == 0
     for c in chunks:
         assert 0 <= c.start < c.end <= len(code)
+
+
+def test_get_parser(caplog: pytest.LogCaptureFixture) -> None:
+    """Test that get parser only logs the first time."""
+    _cached_get_parser.cache_clear()
+    with caplog.at_level(logging.WARNING, logger="semble.chunking.core"):
+        _cached_get_parser("hello")
+        assert len(caplog.records) == 1
+        assert "hello" in caplog.records[0].message
+
+        caplog.clear()
+        _cached_get_parser("hello")
+        assert len(caplog.records) == 0
+
+
+def test_chunks_is_none() -> None:
+    """Test that chunk returns None when parser is not available."""
+    with patch("semble.chunking.core._cached_get_parser", lambda x: None):
+        chunks = chunk("x = 1", "python", 10)
+        assert chunks is None

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -2,9 +2,18 @@ import logging
 from unittest.mock import patch
 
 import pytest
+from tree_sitter_language_pack import DownloadError
 
 from semble.chunking.chunking import Chunk, chunk_lines, chunk_source
 from semble.chunking.core import ChunkBoundary, _cached_get_parser, chunk
+
+
+@pytest.fixture(autouse=True)
+def clear_parser_cache():
+    """Clear the parser cache in between tests."""
+    _cached_get_parser.cache_clear()
+    yield
+    _cached_get_parser.cache_clear()
 
 
 def test_chunk_lines() -> None:
@@ -86,15 +95,44 @@ def test_get_parser(caplog: pytest.LogCaptureFixture) -> None:
     with caplog.at_level(logging.WARNING, logger="semble.chunking.core"):
         _cached_get_parser("hello")
         assert len(caplog.records) == 1
+        assert "not found" in caplog.records[0].message
         assert "hello" in caplog.records[0].message
 
         caplog.clear()
         _cached_get_parser("hello")
         assert len(caplog.records) == 0
 
+    with patch("semble.chunking.core.get_parser", side_effect=DownloadError):
+        with caplog.at_level(logging.WARNING, logger="semble.chunking.core"):
+            _cached_get_parser("Python")
+            assert len(caplog.records) == 1
+            assert "Failed to download" in caplog.records[0].message
+            assert "Python" in caplog.records[0].message
+
+            caplog.clear()
+            _cached_get_parser("Python")
+            assert len(caplog.records) == 0
+
+    with patch("semble.chunking.core.get_parser", side_effect=ValueError):
+        with caplog.at_level(logging.WARNING, logger="semble.chunking.core"):
+            _cached_get_parser("Ruby")
+            assert len(caplog.records) == 1
+            assert "Uncaught exception" in caplog.records[0].message
+
+            caplog.clear()
+            _cached_get_parser("Ruby")
+            assert len(caplog.records) == 0
+
 
 def test_chunks_is_none() -> None:
     """Test that chunk returns None when parser is not available."""
     with patch("semble.chunking.core._cached_get_parser", lambda x: None):
+        chunks = chunk("x = 1", "python", 10)
+        assert chunks is None
+
+
+def test_download_error() -> None:
+    """Test that chunk returns None when parser is not available."""
+    with patch("semble.chunking.core.get_parser", side_effect=DownloadError):
         chunks = chunk("x = 1", "python", 10)
         assert chunks is None


### PR DESCRIPTION
This PR adds a fallback for parsers from `tree-sitter-language-pack`. If a user can't download a parser for some reason, we warn the user, but only the first time, and then fall back to line chunking.

Closes #111 , #114 and #94 