### PR TITLE
feat: add windsurf and zed targets to semble init

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ If `semble` is not on `$PATH`, use `uvx --from "semble[mcp]" semble` in its plac
 
 ### Sub-agent setup
 
-Claude Code, Gemini CLI, Cursor, OpenCode, GitHub Copilot CLI, and Kiro all support a dedicated semble search sub-agent. Run `semble init` once in your project root:
+Claude Code, Gemini CLI, Cursor, OpenCode, GitHub Copilot CLI, Kiro, Windsurf, and Zed all support a dedicated semble search sub-agent. Run `semble init` once in your project root:
 
 ```bash
 semble init                      # Claude Code  → .claude/agents/semble-search.md
@@ -336,6 +336,8 @@ semble init --agent cursor       # Cursor       → .cursor/agents/semble-search
 semble init --agent opencode     # OpenCode     → .opencode/agents/semble-search.md
 semble init --agent copilot      # Copilot CLI  → .github/agents/semble-search.md
 semble init --agent kiro         # Kiro         → .kiro/agents/semble-search.md
+semble init --agent windsurf     # Windsurf     → .codeium/windsurf/agents/semble-search.md
+semble init --agent zed          # Zed          → .config/zed/agents/semble-search.md
 ```
 
 If semble is not on `$PATH`, prefix the command with `uvx --from "semble[mcp]"`.

--- a/src/semble/cli.py
+++ b/src/semble/cli.py
@@ -20,6 +20,8 @@ class Agent(str, Enum):
     GEMINI = "gemini"
     KIRO = "kiro"
     OPENCODE = "opencode"
+    WINDSURF = "windsurf"
+    ZED = "zed"
 
 
 _DEFAULT_AGENT = Agent.CLAUDE
@@ -28,7 +30,14 @@ _CLI_DISPATCH_ARGS = frozenset({"search", "find-related", "init", "savings", "-h
 
 def _agent_path(agent: Agent) -> Path:
     """Return the project-relative path where the semble sub-agent file should be written."""
-    base_dir = ".github" if agent is Agent.COPILOT else f".{agent.value}"
+    if agent is Agent.COPILOT:
+        base_dir = ".github"
+    elif agent is Agent.WINDSURF:
+        base_dir = ".codeium/windsurf"
+    elif agent is Agent.ZED:
+        base_dir = ".config/zed"
+    else:
+        base_dir = f".{agent.value}"
     return Path(base_dir) / "agents" / "semble-search.md"
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -129,6 +129,24 @@ def test_init_overwrites_with_force(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     assert dest.read_text(encoding="utf-8") == _CLAUDE_AGENT_FILE
 
 
+@pytest.mark.parametrize(
+    ("agent", "expected_relpath"),
+    [
+        (Agent.WINDSURF, Path('.codeium/windsurf/agents/semble-search.md')),
+        (Agent.ZED, Path('.config/zed/agents/semble-search.md')),
+    ],
+)
+def test_agent_specific_init_paths(
+    agent: Agent, expected_relpath: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """_run_init writes agent files to the documented per-agent paths."""
+    monkeypatch.chdir(tmp_path)
+    _run_init(agent=agent)
+    dest = tmp_path / expected_relpath
+    assert dest.exists()
+    assert str(expected_relpath) in capsys.readouterr().out
+
+
 def test_init_via_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
     """Semble init creates the Claude agent file via _cli_main."""
     monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
## Summary\n- add  and  as supported  targets\n- write agent files to the documented paths for each tool\n- document the new init commands in README\n- add focused tests for the new output paths\n\n## Why\nThe README already documents MCP setup for Windsurf and Zed, but the dedicated sub-agent setup section did not support them via . This change keeps the CLI aligned with the docs and extends an existing workflow in a small, low-risk way.\n\n## Verification\n- added targeted tests for the new agent output paths in \n- local test execution was partially blocked by missing optional dependency  in the current environment, so I verified the changed path logic directly and kept the change surface small