### PR TITLE
feat: check depth and chunk bounds to prevent recursion errors

### DIFF
--- a/src/semble/chunking/core.py
+++ b/src/semble/chunking/core.py
@@ -11,6 +11,9 @@ from semble.index.files import ALL_LANGUAGES
 
 logger = getLogger(__name__)
 
+_RECURSION_DEPTH = 500
+_MIN_CHUNK_SIZE = 50
+
 
 def is_supported_language(language: str) -> bool:
     """Check if the language is supported by tree-sitter."""
@@ -77,11 +80,11 @@ def _merge_node_inner(node: Node, desired_length: int, i: int) -> list[ChunkBoun
 
     length = node.end_byte - node.start_byte
     # Prevent recursion issues. A depth of > 500 is unlikely
-    if i > 500:
+    if i > _RECURSION_DEPTH:
         logger.warning("Recursion depth exceeded in chunk.")
         return [ChunkBoundary(node.start_byte, node.end_byte)]
     # Prevent recursing into short chunks.
-    if length < 50:
+    if length < _MIN_CHUNK_SIZE:
         return [ChunkBoundary(node.start_byte, node.end_byte)]
 
     groups: list[ChunkBoundary] = []

--- a/src/semble/chunking/core.py
+++ b/src/semble/chunking/core.py
@@ -80,7 +80,7 @@ def _merge_node_inner(node: Node, desired_length: int, i: int) -> list[ChunkBoun
     if i > 500:
         return [ChunkBoundary(node.start_byte, node.end_byte)]
     # Prevent recursing into short chunks.
-    if length < 250:
+    if length < 50:
         return [ChunkBoundary(node.start_byte, node.end_byte)]
 
     groups: list[ChunkBoundary] = []

--- a/src/semble/chunking/core.py
+++ b/src/semble/chunking/core.py
@@ -69,10 +69,18 @@ def _merge_adjacent_chunks(
     return merged
 
 
-def _merge_node_inner(node: Node, desired_length: int) -> list[ChunkBoundary]:
+def _merge_node_inner(node: Node, desired_length: int, i: int) -> list[ChunkBoundary]:
     """Recursively merge and split nodes."""
     # If there are no child nodes, the only thing we can do is return the current node.
     if not node.children:
+        return [ChunkBoundary(node.start_byte, node.end_byte)]
+
+    length = node.end_byte - node.start_byte
+    # Prevent recursion issues. A depth of > 500 is unlikely
+    if i > 500:
+        return [ChunkBoundary(node.start_byte, node.end_byte)]
+    # Prevent recursing into short chunks.
+    if length < 250:
         return [ChunkBoundary(node.start_byte, node.end_byte)]
 
     groups: list[ChunkBoundary] = []
@@ -90,7 +98,7 @@ def _merge_node_inner(node: Node, desired_length: int) -> list[ChunkBoundary]:
         # If this single chunk is longer than the desired length
         # we try to split it again.
         if length > desired_length:
-            groups.extend(_merge_node_inner(child, desired_length))
+            groups.extend(_merge_node_inner(child, desired_length, i + 1))
             continue
 
         while index < len(children):
@@ -112,7 +120,7 @@ def _merge_node_inner(node: Node, desired_length: int) -> list[ChunkBoundary]:
 
 def _merge_node(node: Node, desired_length: int) -> list[ChunkBoundary]:
     """Recursively turn nodes into chunks, then merge adjacent chunks."""
-    raw_chunks = _merge_node_inner(node, desired_length)
+    raw_chunks = _merge_node_inner(node, desired_length, 0)
     return _merge_adjacent_chunks(raw_chunks, desired_length)
 
 

--- a/src/semble/chunking/core.py
+++ b/src/semble/chunking/core.py
@@ -78,6 +78,7 @@ def _merge_node_inner(node: Node, desired_length: int, i: int) -> list[ChunkBoun
     length = node.end_byte - node.start_byte
     # Prevent recursion issues. A depth of > 500 is unlikely
     if i > 500:
+        logger.warning("Recursion depth exceeded in chunk.")
         return [ChunkBoundary(node.start_byte, node.end_byte)]
     # Prevent recursing into short chunks.
     if length < 50:

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -136,3 +136,15 @@ def test_download_error() -> None:
     with patch("semble.chunking.core.get_parser", side_effect=DownloadError):
         chunks = chunk("x = 1", "python", 10)
         assert chunks is None
+
+
+def test_chunker_deep_string(caplog: pytest.LogCaptureFixture) -> None:
+    """Test that chunking works with a very deep string."""
+    deep_string = "abs(0)\n"
+    for _ in range(10000):
+        deep_string = f"abs({deep_string})\n"
+    with caplog.at_level(logging.WARNING, logger="semble.chunking.core"):
+        chunks = chunk_source(deep_string, "deep_string.py", "python")
+        assert chunks is not None
+        assert len(caplog.records) == 1
+        assert "Recursion depth exceeded in chunk." in caplog.records[0].message


### PR DESCRIPTION
This PR checks the depth of the tree when chunking as well as a lower bound on chunk length. Shows an admittedly uninformative warning when the limit is hit, so the user is aware.
No change in scores, runtime or indexing time, so this is a just a fix for degenerate cases.

Fixes #121 