### PR TITLE
fix: tree-sitter 0.25+ API compatibility in chunking

### DIFF
--- a/spec/042-fix-bytes-str-tree-sitter-parse/SPEC.md
+++ b/spec/042-fix-bytes-str-tree-sitter-parse/SPEC.md
@@ -1,0 +1,30 @@
+# Spec: Fix bytes-vs-str TypeError in tree-sitter Parser.parse()
+
+## Feedback ID
+bug-20260521-26ea06
+
+## Problem
+`semble chunking.core.chunk()` passes `bytes` (via `text.encode("utf-8")`) to `parser.parse()`.
+Starting with tree-sitter 0.24+, `Parser.parse()` requires `str`, not `bytes`.
+This causes a `TypeError: argument 'source': 'bytes' object is not an instance of 'str'`
+when running `semble --include-text-files` on any repo.
+
+## Root Cause
+In `src/semble/chunking/core.py`, line:
+```python
+as_bytes = text.encode("utf-8")
+root = parser.parse(as_bytes).root_node  # BUG: bytes not accepted by tree-sitter>=0.24
+```
+
+## Fix
+Pass `text` (str) directly to `parser.parse()` instead of `as_bytes` (bytes).
+Keep `as_bytes` for the byte-to-character offset conversion loop since tree-sitter
+nodes still expose `start_byte`/`end_byte` attributes.
+
+## Test
+Add a regression test that directly calls `chunk()` with a Python code string
+and verifies it returns valid ChunkBoundary objects without TypeError.
+
+## Verification
+- `uv run pytest tests/test_chunker.py` passes
+- `semble --include-text-files /root/gitrepos/demos` no longer crashes with TypeError

--- a/src/semble/chunking/core.py
+++ b/src/semble/chunking/core.py
@@ -5,7 +5,7 @@ from functools import cache
 from logging import getLogger
 
 from tree_sitter import Node, Parser
-from tree_sitter_language_pack import DownloadError, LanguageNotFoundError, SupportedLanguage, get_parser
+from tree_sitter_language_pack import LanguageNotFoundError, SupportedLanguage, get_parser
 
 from semble.index.files import ALL_LANGUAGES
 
@@ -35,8 +35,6 @@ def _cached_get_parser(language: SupportedLanguage) -> Parser | None:
         return get_parser(language)
     except LanguageNotFoundError:
         logger.warning("Language %s not found, falling back to line chunking", language)
-    except DownloadError:
-        logger.warning("Failed to download language %s, falling back to line chunking", language)
     except Exception:
         logger.error("Uncaught exception in _cached_get_parser", exc_info=True)
     return None
@@ -72,30 +70,74 @@ def _merge_adjacent_chunks(
     return merged
 
 
+def _node_start_byte(node: Node) -> int:
+    """Get the start byte offset of a node, compatible with tree-sitter 0.25+."""
+    val = node.start_byte
+    return val() if callable(val) else val
+
+
+def _node_end_byte(node: Node) -> int:
+    """Get the end byte offset of a node, compatible with tree-sitter 0.25+."""
+    val = node.end_byte
+    return val() if callable(val) else val
+
+
+def _node_child_count(node: Node) -> int:
+    """Get the number of children of a node, compatible with tree-sitter 0.25+."""
+    # tree-sitter <0.24: node.children is a list
+    if hasattr(node, "children") and isinstance(node.children, list):
+        return len(node.children)
+    # tree-sitter >=0.25: node.child_count() is a method
+    val = node.child_count
+    return val() if callable(val) else val
+
+
+def _node_child(node: Node, index: int) -> Node:
+    """Get the i-th child of a node, compatible with tree-sitter 0.25+."""
+    # tree-sitter <0.24: node.children is a list
+    if hasattr(node, "children") and isinstance(node.children, list):
+        return node.children[index]
+    # tree-sitter >=0.25: node.child(i) is a method
+    return node.child(index)
+
+
+def _node_children(node: Node) -> list[Node]:
+    """Get all children of a node as a list, compatible with tree-sitter 0.25+."""
+    # tree-sitter <0.24: node.children is a list
+    if hasattr(node, "children") and isinstance(node.children, list):
+        return node.children
+    # tree-sitter >=0.25: use child(i) + child_count()
+    count = _node_child_count(node)
+    return [node.child(i) for i in range(count)]
+
+
 def _merge_node_inner(node: Node, desired_length: int, i: int) -> list[ChunkBoundary]:
     """Recursively merge and split nodes."""
+    child_count = _node_child_count(node)
     # If there are no child nodes, the only thing we can do is return the current node.
-    if not node.children:
-        return [ChunkBoundary(node.start_byte, node.end_byte)]
+    if child_count == 0:
+        return [ChunkBoundary(_node_start_byte(node), _node_end_byte(node))]
 
-    length = node.end_byte - node.start_byte
+    start_byte = _node_start_byte(node)
+    end_byte = _node_end_byte(node)
+    length = end_byte - start_byte
     # Prevent recursion issues. A depth of > 500 is unlikely
     if i > _RECURSION_DEPTH:
         logger.warning("Recursion depth exceeded in chunk.")
-        return [ChunkBoundary(node.start_byte, node.end_byte)]
+        return [ChunkBoundary(start_byte, end_byte)]
     # Prevent recursing into short chunks.
     if length < _MIN_CHUNK_SIZE:
-        return [ChunkBoundary(node.start_byte, node.end_byte)]
+        return [ChunkBoundary(start_byte, end_byte)]
 
     groups: list[ChunkBoundary] = []
-    children = node.children
+    children = _node_children(node)
     index = 0
 
     while index < len(children):
         child = children[index]
-        start = child.start_byte
-        end = child.end_byte
-        length = child.end_byte - child.start_byte
+        start = _node_start_byte(child)
+        end = _node_end_byte(child)
+        length = end - start
 
         # Increment the pointer, as we accessed a child node.
         index += 1
@@ -108,12 +150,14 @@ def _merge_node_inner(node: Node, desired_length: int, i: int) -> list[ChunkBoun
         while index < len(children):
             # Extend the current group with or more children, if they fit.
             child = children[index]
-            child_length = child.end_byte - child.start_byte
+            child_start = _node_start_byte(child)
+            child_end = _node_end_byte(child)
+            child_length = child_end - child_start
 
             if length + child_length > desired_length:
                 break
 
-            end = child.end_byte
+            end = child_end
             length += child_length
             index += 1
 
@@ -150,7 +194,9 @@ def chunk(text: str, language: str, desired_length: int) -> list[ChunkBoundary] 
     parser = _cached_get_parser(language)
     if parser is None:
         return None
-    root = parser.parse(as_bytes).root_node
+    tree = parser.parse(text)
+    # tree-sitter >=0.25: root_node is a method; <0.24: it is a property.
+    root = tree.root_node() if callable(tree.root_node) else tree.root_node
 
     chunks = []
     for chunk_boundary in _merge_node(root, desired_length):

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -148,3 +148,21 @@ def test_chunker_deep_string(caplog: pytest.LogCaptureFixture) -> None:
         assert chunks is not None
         assert len(caplog.records) == 1
         assert "Recursion depth exceeded in chunk." in caplog.records[0].message
+
+
+def test_core_chunk_passes_str_to_parser() -> None:
+    """Regression test: chunk() must pass str (not bytes) to tree-sitter Parser.parse().
+
+    tree-sitter >= 0.24 requires str input.  Passing bytes causes:
+        TypeError: argument 'source': 'bytes' object is not an instance of 'str'
+
+    Refs: bug-20260521-26ea06
+    """
+    code = "def hello():\n    return 'world'\n"
+    # Should not raise TypeError
+    chunks = chunk(code, "python", 100)
+    assert chunks is not None
+    assert len(chunks) >= 1
+    # Chunks must cover the full source text
+    reconstructed = "".join(code[c.start : c.end] for c in chunks)
+    assert reconstructed == code


### PR DESCRIPTION
## Problem

`semble search --include-text-files` crashes with `TypeError: argument 'source': 'bytes' object is not an instance of 'str'` when using tree-sitter >= 0.24.

The tree-sitter Python bindings changed their API in 0.24+:
- `Parser.parse()` now requires `str` instead of `bytes`
- `tree.root_node` is now a method (`tree.root_node()`), not a property
- `Node.children` no longer exists; must use `node.child(i)` + `node.child_count()`
- `Node.start_byte`/`end_byte` are now methods, not properties

Since `pyproject.toml` declares `tree-sitter>=0.25`, all these API changes are in effect and the existing code crashes.

## Fix

Add runtime-compatible helper functions in `core.py` that detect which API variant is active and call it appropriately:

- `_node_start_byte(node)` / `_node_end_byte(node)` — handles both property and method access
- `_node_child_count(node)` — handles `len(node.children)` and `node.child_count()`
- `_node_child(node, i)` — handles `node.children[i]` and `node.child(i)`
- `_node_children(node)` — returns a list in both API variants
- `chunk()` now passes `str` to `parser.parse()` and calls `tree.root_node()` as a method with property fallback

This keeps semble compatible with both old (<0.24) and new (>=0.25) tree-sitter versions.

Also removes the `DownloadError` import which was removed from `tree-sitter-language-pack` in newer versions.

## Testing

- Manually validated against tree-sitter 0.25.2 with `semble search --include-text-files` on a real repo (no more TypeError)
- Round-trip test: chunked Python source reconstructs to identical text
- Regression test added: `test_core_chunk_passes_str_to_parser`

## Refs

Feedback ID: bug-20260521-26ea06