### PR TITLE
chore: upper pin tree sitter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "numpy>=1.24.0",
     "bm25s>=0.2.0",
     "pathspec>=0.12",
-    "tree-sitter>=0.25",
+    "tree-sitter>=0.25,<0.26",
     "tree-sitter-language-pack>=1.0,<1.8.0,!=1.6.3"
 ]
 


### PR DESCRIPTION
We didn't have an upper bound on `tree-sitter`, but `tree-sitter-language-pack`, which we pin exactly, doesn't pin `tree-sitter` at all. So, in effect, if `tree-sitter` ever updates to a new major, we could install a version of `tree-sitter` that is not compatible with `tree-sitter-language-pack`. This PR pins `tree-sitter` to <0.26 to prevent this.

Related to #128 although that was 100% hallucinated.