### PR TITLE
docs: improve Zed MCP setup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Add to `~/.kiro/settings/mcp.json` (or `.kiro/settings/mcp.json` in your project
 <details>
 <summary>Zed</summary>
 
-Add to `~/.config/zed/settings.json` (or `.zed/settings.json` in your project):
+**Via settings** — add to `~/.config/zed/settings.json` (or `.zed/settings.json` in your project):
 
 ```json
 {
@@ -273,6 +273,20 @@ Add to `~/.config/zed/settings.json` (or `.zed/settings.json` in your project):
       "command": "uvx",
       "args": ["--from", "semble[mcp]", "semble"]
     }
+  }
+}
+```
+
+**Via UI** — in the Agent Panel:
+
+1. Open **MCP Servers** → **Add Custom Server...** → **Local**
+2. Paste:
+
+```json
+{
+  "semble": {
+    "command": "uvx",
+    "args": ["--from", "semble[mcp]", "semble", "mcp"]
   }
 }
 ```


### PR DESCRIPTION
# Summary

Improves the Zed documentation in the README by adding explicit setup instructions for the MCP server through the Zed UI.

The docs now cover both:

- configuration via `settings.json`
- configuration via the Agent Panel UI

---

# Changes

## Added

### Zed setup via UI

New instructions for configuring Semble through:

```text
Agent Panel → MCP Servers → Add Custom Server... → Local
```

Including a ready-to-paste JSON example:

```json
{
  "semble": {
    "command": "uvx",
    "args": ["--from", "semble[mcp]", "semble", "mcp"]
  }
}
```

---

# Existing setup preserved

The existing `settings.json` configuration remains documented:

```json
{
  "context_servers": {
    "semble": {
      "command": "uvx",
      "args": ["--from", "semble[mcp]", "semble"]
    }
  }
}
```

---

# Why

Many users configure MCP servers directly through the Zed UI instead of editing `settings.json`.

Documenting both approaches improves onboarding and helps avoid confusion around the required `mcp` subcommand when using the UI flow.

---

# Tested

- Zed local MCP server setup
- Agent Panel custom server flow
- `settings.json` configuration
- `uvx --from "semble[mcp]" semble mcp`