### PR TITLE
fix(mcp): honor --ref when using the default pre-indexed repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Add to `~/.kiro/settings/mcp.json` (or `.kiro/settings/mcp.json` in your project
 <details>
 <summary>Zed</summary>
 
-Add to `~/.config/zed/settings.json` (or `.zed/settings.json` in your project):
+**Via settings** — add to `~/.config/zed/settings.json` (or `.zed/settings.json` in your project):
 
 ```json
 {
@@ -273,6 +273,20 @@ Add to `~/.config/zed/settings.json` (or `.zed/settings.json` in your project):
       "command": "uvx",
       "args": ["--from", "semble[mcp]", "semble"]
     }
+  }
+}
+```
+
+**Via UI** — in the Agent Panel:
+
+1. Open **MCP Servers** → **Add Custom Server...** → **Local**
+2. Paste:
+
+```json
+{
+  "semble": {
+    "command": "uvx",
+    "args": ["--from", "semble[mcp]", "semble", "mcp"]
   }
 }
 ```

--- a/src/semble/mcp.py
+++ b/src/semble/mcp.py
@@ -26,9 +26,24 @@ _REPO_DESCRIPTION = (
 _CACHE_MAX_SIZE = 10  # Max number of cached indexes to keep in memory
 
 
+def _resolve_ref(
+    repo: str | None,
+    source: str,
+    default_source: str | None,
+    default_ref: str | None,
+) -> str | None:
+    """Return the git ref to use when indexing *source*."""
+    if not _is_git_url(source):
+        return None
+    if repo is None or source == default_source:
+        return default_ref
+    return None
+
+
 async def _get_index(
     repo: str | None,
     default_source: str | None,
+    default_ref: str | None,
     cache: _IndexCache,
 ) -> SembleIndex:
     """Return a cached index for a repo, rejecting unsafe git transport schemes."""
@@ -40,13 +55,18 @@ async def _get_index(
             "No repo specified and no default index. "
             "Pass an https:// or http:// git URL or local directory path as `repo`."
         )
+    ref = _resolve_ref(repo, source, default_source, default_ref)
     try:
-        return await cache.get(source)
+        return await cache.get(source, ref=ref)
     except Exception as exc:
         raise ValueError(f"Failed to index {source!r}: {exc}") from exc
 
 
-def create_server(cache: _IndexCache, default_source: str | None = None) -> FastMCP:
+def create_server(
+    cache: _IndexCache,
+    default_source: str | None = None,
+    default_ref: str | None = None,
+) -> FastMCP:
     """Build and return a configured FastMCP server backed by the given cache."""
     server = FastMCP(
         "semble",
@@ -71,7 +91,7 @@ def create_server(cache: _IndexCache, default_source: str | None = None) -> Fast
         Use this to find where something is implemented, understand a library, or locate related code.
         """
         try:
-            index = await _get_index(repo, default_source, cache)
+            index = await _get_index(repo, default_source, default_ref, cache)
         except ValueError as exc:
             return str(exc)
         results = index.search(query, top_k=top_k)
@@ -95,7 +115,7 @@ def create_server(cache: _IndexCache, default_source: str | None = None) -> Fast
         Pass file_path and line from a prior search result.
         """
         try:
-            index = await _get_index(repo, default_source, cache)
+            index = await _get_index(repo, default_source, default_ref, cache)
         except ValueError as exc:
             return str(exc)
         chunk = _resolve_chunk(index.chunks, file_path, line)
@@ -135,7 +155,7 @@ async def serve(path: str | None = None, ref: str | None = None, include_text_fi
                 await cache.start_watcher(path)
 
     init_task = asyncio.create_task(_load_and_prewarm())
-    server = create_server(cache, default_source=path)
+    server = create_server(cache, default_source=path, default_ref=ref)
     try:
         await server.run_stdio_async()
     finally:
@@ -170,8 +190,8 @@ class _IndexCache:
         is_git = _is_git_url(source)
         return (f"{source}@{ref}" if ref else source) if is_git else str(Path(source).resolve())
 
-    def evict(self, source: str) -> None:
-        self._tasks.pop(self._compute_cache_key(source), None)
+    def evict(self, source: str, ref: str | None = None) -> None:
+        self._tasks.pop(self._compute_cache_key(source, ref), None)
 
     async def start_watcher(self, path: str) -> None:
         """Start a background task that re-indexes the path whenever files change."""
@@ -224,10 +244,10 @@ class _IndexCache:
             return await asyncio.shield(task)
         except asyncio.CancelledError:  # pragma: no cover
             if task.done():
-                self.evict(source)
+                self.evict(source, ref=ref)
             raise
         except Exception:
             # Only evict if this task hasn't already been replaced by evict()+get().
             if self._tasks.get(cache_key) is task:
-                self.evict(source)
+                self.evict(source, ref=ref)
             raise

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from semble.mcp import _CACHE_MAX_SIZE, _IndexCache, create_server, serve
+from semble.mcp import _CACHE_MAX_SIZE, _get_index, _IndexCache, create_server, serve
 from semble.types import Chunk, Encoder, SearchResult
 from semble.utils import _format_results, _is_git_url, _resolve_chunk
 from tests.conftest import make_chunk
@@ -120,6 +120,49 @@ async def test_index_cache_builds_and_caches(
     assert first is fake_index
     assert second is fake_index
     mock_build.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_index_cache_git_ref_key(cache: _IndexCache) -> None:
+    """Git URLs with a ref use a distinct cache key and reuse the same build."""
+    url = "https://github.com/org/repo"
+    fake_index = MagicMock()
+    with patch("semble.mcp.SembleIndex.from_git", return_value=fake_index) as mock_build:
+        first = await cache.get(url, ref="v1.0")
+        second = await cache.get(url, ref="v1.0")
+    assert first is fake_index
+    assert second is fake_index
+    mock_build.assert_called_once()
+    assert mock_build.call_args.kwargs["ref"] == "v1.0"
+
+
+@pytest.mark.anyio
+async def test_get_index_reuses_default_ref(cache: _IndexCache) -> None:
+    """Tool lookups without repo reuse the startup --ref cache entry."""
+    url = "https://github.com/org/repo"
+    fake_index = MagicMock()
+    with patch("semble.mcp.SembleIndex.from_git", return_value=fake_index) as mock_build:
+        await cache.get(url, ref="main")
+        index = await _get_index(None, url, "main", cache)
+        await _get_index(url, url, "main", cache)
+    assert index is fake_index
+    assert mock_build.call_count == 1
+
+
+@pytest.mark.anyio
+async def test_tool_search_reuses_default_ref_cache(cache: _IndexCache) -> None:
+    """Search without repo hits the pre-indexed default git ref."""
+    url = "https://github.com/org/repo"
+    chunk = make_chunk("def bar(): pass", "src/bar.py")
+    fake_index = MagicMock()
+    fake_index.search.return_value = [SearchResult(chunk=chunk, score=0.9)]
+    with patch("semble.mcp.SembleIndex.from_git", return_value=fake_index) as mock_build:
+        await cache.get(url, ref="main")
+        mock_build.reset_mock()
+        server = create_server(cache, default_source=url, default_ref="main")
+        result = await server.call_tool("search", {"query": "bar"})
+    assert "bar" in _tool_text(result)
+    mock_build.assert_not_called()
 
 
 @pytest.mark.anyio
@@ -375,6 +418,15 @@ def test_cache_evict(cache: _IndexCache, tmp_path: Path) -> None:
 def test_cache_evict_missing(cache: _IndexCache, tmp_path: Path) -> None:
     """evict() on an unknown path is a no-op."""
     cache.evict(str(tmp_path))  # should not raise
+
+
+def test_cache_evict_with_ref(cache: _IndexCache) -> None:
+    """evict() removes git cache entries that include a ref in the key."""
+    url = "https://github.com/org/repo"
+    key = f"{url}@main"
+    cache._tasks[key] = MagicMock()
+    cache.evict(url, ref="main")
+    assert key not in cache._tasks
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

Fix an MCP cache inconsistency when the server is started with a git repository URL and `--ref`, but subsequent `search` / `find_related` tool calls omit `repo`.

Previously:

* startup prewarming indexed the repository using a cache key like `url@ref`
* tool calls without `repo` resolved cache entries using only `url`
* this caused cache misses and unnecessary re-cloning/re-indexing of the repository default branch

This change ensures that tool calls targeting the default startup repository consistently reuse the same pre-warmed cache entry.

---

## Changes

### Ref-aware default source resolution

Added `_resolve_ref()` behavior so git URLs use `default_ref` when:

* `repo is None`
* `repo == default_source`

This allows MCP tools to correctly reuse the startup repository reference.

---

### Ref-aware cache lookups

`_get_index()` now resolves and forwards the effective `ref` into:

```python
cache.get(source, ref=ref)
```

instead of always using only the source URL.

---

### Propagate default ref through server startup

`create_server()` now accepts:

```python
default_ref: str | None
```

and `serve()` forwards the startup `--ref` value into MCP tool resolution.

---

### Ref-aware eviction

`evict()` now accepts an optional `ref` argument so git cache keys such as:

```text
url@ref
```

are correctly removed during failures or cancellations.

This prevents orphaned cache entries.

---

## Test Plan

* [x] `uv run pytest tests/test_mcp.py -q`
* [x] `uv run ruff check src/semble/mcp.py tests/test_mcp.py`
* [x] `uv run mypy src/semble/mcp.py`

### Added Tests

* `test_index_cache_git_ref_key`
* `test_get_index_reuses_default_ref`
* `test_tool_search_reuses_default_ref_cache`
* `test_cache_evict_with_ref`

---

## Behavior Before

```text
startup:
  cache key -> url@ref

tool call without repo:
  cache lookup -> url

=> cache miss
=> second clone/index on default branch
```

---

## Behavior After

```text
startup:
  cache key -> url@ref

tool call without repo:
  cache lookup -> url@ref

=> cache reuse
=> no unnecessary re-index
```

---

## Compatibility

No public API changes to `SembleIndex`.

No behavioral changes for:

* local paths
* non-git repositories
* existing MCP tool usage without `--ref`

This only affects internal cache resolution for default git startup repositories.

---

## Manual Verification

```bash
semble https://github.com/MinishLab/semble --ref <tag-or-branch>
```

Then invoke MCP `search` / `find_related` without `repo`.

Expected behavior:

* no second clone
* no second indexing pass
* same pre-warmed cache entry reused
