### PR TITLE
fix: default MCP search to server cwd

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Add Semble to Claude Code (requires [uv](https://docs.astral.sh/uv/getting-start
 claude mcp add semble -s user -- uvx --from "semble[mcp]" semble
 ```
 
+When started without a path, the MCP server uses its current working directory as the default local repo. Tool calls can omit `repo` for that default, or pass an explicit local path / `https://` URL to search another repo.
+
 Using another agent harness? See [MCP Server](#mcp-server) below for per-agent setup.
 
 ### Bash / AGENTS.md
@@ -134,6 +136,8 @@ uv cache clean semble          # for MCP users (restart your MCP client after)
 ## MCP Server
 
 Semble can run as an MCP server so agents can search any codebase directly. Repos are cloned and indexed on demand, and indexes are cached for the lifetime of the session. Local paths are watched for file changes and re-indexed automatically.
+
+If the MCP server starts without a path argument, its current working directory becomes the default local source. Calls to `search` and `find_related` may omit `repo` to use that default. Pass `repo` explicitly when searching another local repo or any remote repo.
 
 ### Setup
 

--- a/src/semble/mcp.py
+++ b/src/semble/mcp.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 _REPO_DESCRIPTION = (
     "https:// or http:// git URL (e.g. https://github.com/org/repo) or local directory path to index and search. "
-    "Required when no default index was configured at startup. "
+    "Defaults to the MCP server's startup path, or its current working directory if no startup path was provided. "
     "The index is cached after the first call, so repeat queries are fast."
 )
 
@@ -55,7 +55,8 @@ def create_server(cache: _IndexCache, default_source: str | None = None) -> Fast
         instructions=(
             "Instant code search for any local or remote git repository. "
             "Call `search` to find relevant code; call `find_related` on a result to discover similar code elsewhere. "
-            "When working in a local project, pass the project root as `repo`. "
+            "When working in a local project, omit `repo` to use the MCP server's default local source, "
+            "or pass a project root explicitly to search another local repository. "
             "For remote repos, pass an explicit https:// URL. Never guess or infer URLs. "
             "Prefer these tools over Grep, Glob, or Read for any question about how code works."
         ),
@@ -114,6 +115,11 @@ def create_server(cache: _IndexCache, default_source: str | None = None) -> Fast
     return server
 
 
+def _resolve_default_source(path: str | None) -> str:
+    """Resolve the local default source used when MCP tool calls omit repo."""
+    return path if path is not None else str(Path.cwd().resolve())
+
+
 async def serve(
     path: str | None = None,
     ref: str | None = None,
@@ -121,6 +127,7 @@ async def serve(
 ) -> None:
     """Start an MCP stdio server, optionally pre-indexing a default source."""
     cache = _IndexCache(content=content)
+    default_source = _resolve_default_source(path)
 
     async def _load_and_prewarm() -> None:
         """Pre-load the model and optionally pre-index the default source in parallel with starting the server."""
@@ -132,16 +139,16 @@ async def serve(
             return
         finally:
             cache._model_ready.set()
-        if path:
+        if default_source:
             try:
-                await cache.get(path, ref=ref)
+                await cache.get(default_source, ref=ref)
             except Exception:
-                logger.warning("Failed to pre-index %r at startup", path, exc_info=True)
-            if not is_git_url(path):
-                await cache.start_watcher(path)
+                logger.warning("Failed to pre-index %r at startup", default_source, exc_info=True)
+            if not is_git_url(default_source):
+                await cache.start_watcher(default_source)
 
     init_task = asyncio.create_task(_load_and_prewarm())
-    server = create_server(cache, default_source=path)
+    server = create_server(cache, default_source=default_source)
     try:
         await server.run_stdio_async()
     finally:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -162,6 +162,38 @@ async def test_tool_no_repo_no_default(cache: _IndexCache, tool: str, args: dict
 
 
 @pytest.mark.anyio
+async def test_tool_uses_default_source_when_repo_omitted(cache: _IndexCache, tmp_path: Path) -> None:
+    """Tool calls without repo use the server's default source."""
+    fake_index = MagicMock()
+    fake_index.search.return_value = [SearchResult(chunk=make_chunk("def local(): pass", "local.py"), score=0.7)]
+
+    with patch("semble.mcp.SembleIndex.from_path", return_value=fake_index) as mock_from_path:
+        server = create_server(cache, default_source=str(tmp_path))
+        result = await server.call_tool("search", {"query": "local"})
+
+    assert "local.py" in _tool_text(result)
+    mock_from_path.assert_called_once()
+    assert mock_from_path.call_args.args[0] == str(tmp_path.resolve())
+
+
+@pytest.mark.anyio
+async def test_tool_prefers_explicit_repo_over_default_source(cache: _IndexCache, tmp_path: Path) -> None:
+    """Explicit repo takes precedence over any server default source."""
+    default_source = tmp_path / "default"
+    explicit_repo = tmp_path / "explicit"
+    fake_index = MagicMock()
+    fake_index.search.return_value = [SearchResult(chunk=make_chunk("def explicit(): pass", "explicit.py"), score=0.7)]
+
+    with patch("semble.mcp.SembleIndex.from_path", return_value=fake_index) as mock_from_path:
+        server = create_server(cache, default_source=str(default_source))
+        result = await server.call_tool("search", {"query": "explicit", "repo": str(explicit_repo)})
+
+    assert "explicit.py" in _tool_text(result)
+    mock_from_path.assert_called_once()
+    assert mock_from_path.call_args.args[0] == str(explicit_repo.resolve())
+
+
+@pytest.mark.anyio
 @pytest.mark.parametrize(
     ("tool", "args"),
     [
@@ -283,6 +315,27 @@ async def test_serve_runs_stdio(
         await (serve(str(tmp_path)) if with_path else serve())
 
     mock_run.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_serve_defaults_to_cwd_when_no_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """MCP serve without a path uses the process cwd as the local default source."""
+
+    async def fake_stdio() -> None:
+        await asyncio.sleep(0.05)
+
+    monkeypatch.chdir(tmp_path)
+    with (
+        patch("semble.mcp.load_model", return_value=(MagicMock(spec=StaticModel), "/fake/model")),
+        patch("semble.mcp.SembleIndex.from_path", return_value=MagicMock()) as mock_from_path,
+        patch.object(_IndexCache, "start_watcher", new_callable=AsyncMock) as mock_watcher,
+        patch("mcp.server.fastmcp.FastMCP.run_stdio_async", side_effect=fake_stdio),
+    ):
+        await serve()
+
+    mock_from_path.assert_called_once()
+    assert mock_from_path.call_args.args[0] == str(tmp_path.resolve())
+    mock_watcher.assert_awaited_once_with(str(tmp_path.resolve()))
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
fix the issue:Semble MCP fails without explicit repo while CLI falls back to cwd #149
## Summary

This PR makes the MCP server match the CLI's local default behavior. When the MCP server starts without an explicit path, it now uses the server process current working directory as the default local repo. MCP tool calls can omit `repo` for that default local source, while explicit `repo` values still take precedence for cross-repo or remote searches.

## Problem

Before this change, local code search behaved differently between CLI and MCP:

- CLI commands defaulted to the current directory for local searches.
- MCP tool calls failed when both `repo` and startup `default_source` were absent.

That meant an agent running inside a local repository could call the MCP `search` tool without `repo` and unexpectedly get a "No repo specified" error, even though the equivalent CLI workflow worked from the same directory.

## Root Cause

The MCP server only passed through the optional startup `path` as `default_source`. If the server was started without that path, `default_source` stayed empty. Later, tool calls resolved the index source from `repo or default_source`; when both were empty, the call failed.

The gap was not in indexing or search itself. The failure condition was specifically triggered by MCP calls that omitted `repo` while the MCP server had also been started without an explicit default path.

## Changes

- Added centralized default-source resolution in `src/semble/mcp.py`.
- When `serve()` receives no startup path, it resolves `Path.cwd()` and uses that as the MCP default local source.
- Reused the resolved default source for pre-indexing, file watching, and server tool defaults.
- Preserved explicit `repo` precedence, so remote repos and cross-repo local searches still work by passing `repo`.
- Updated MCP instructions and README text to document the new default behavior.
- Added tests covering omitted `repo`, explicit `repo` precedence, and no-path server startup behavior.

## Behavior After This PR

- `mcp search(query=...)` uses the MCP server working directory when no `repo` is passed.
- `mcp search(query=..., repo="E:/Repo/other")` searches the explicit local repo.
- `mcp search(query=..., repo="https://github.com/org/repo")` searches the explicit remote repo.
- Explicit `repo` remains the recommended pattern for multi-repo or remote-repo workflows.

## Verification

- `uv run pytest tests/test_cli.py tests/test_mcp.py -q`
  - Result: passed, `75 passed`
- `uv run ruff check src/ tests/`
  - Result: passed
- `uv run pytest -q`
  - Result: `184 passed, 1 failed`
  - The remaining failure is `tests/test_file_walker.py::test_walk_files_skips_symlinks`, caused by Windows symlink privilege error `WinError 1314`. This is unrelated to the MCP default-repo change.

## Risk

The main behavior change is that MCP servers started without a path now default to their process working directory instead of having no default source. This aligns MCP with the CLI for local repository usage, but agent harnesses should still pass `repo` explicitly when they need deterministic cross-repo behavior.

## Commit

`6468f8c fix: default MCP search to server cwd`