### PR TITLE
Fix sort key in hybrid search candidate ordering

### DIFF
--- a/src/semble/search.py
+++ b/src/semble/search.py
@@ -106,10 +106,10 @@ def search(
     normalized_bm25 = _rrf_scores(bm25_scores)
 
     # Sort by the file path and start line to
-    # counteract randomness introduces by hashing.
+    # counteract randomness introduced by hashing.
     all_candidates = sorted(
         {*normalized_semantic, *normalized_bm25},
-        key=lambda c: c.start_line,
+        key=lambda c: (c.file_path, c.start_line),
     )
     combined_scores: dict[Chunk, float] = {
         chunk: alpha_weight * normalized_semantic.get(chunk, 0.0)


### PR DESCRIPTION
## Summary
- Fixes the sort key in `search()` to sort by `(file_path, start_line)` instead of just `start_line`, matching the comment's stated intent
- Fixes typo "introduces" → "introduced" in the comment

## Problem
The comment on line 108-109 says "Sort by the file path and start line to counteract randomness introduced by hashing", but the actual sort key was only `c.start_line`. This means chunks from different files with the same start line number would have non-deterministic ordering.

## Test plan
- [x] Existing tests pass
- [x] The change is a one-character fix to a sort key — verified that `(c.file_path, c.start_line)` produces deterministic ordering across files

🤖 Generated with [Claude Code](https://claude.com/claude-code)