### PR TITLE
Persist content types in index metadata on save/restore on load

### DIFF
--- a/src/semble/index/index.py
+++ b/src/semble/index/index.py
@@ -305,7 +305,10 @@ class SembleIndex:
 
         model, model_path = load_model(model_path)
 
-        return cls(model, bm_25_index, semantic_index, chunks, model_path, root=root_path)
+        content_strs = metadata.get("content", ["code"])
+        content = tuple(ContentType(c) for c in content_strs)
+
+        return cls(model, bm_25_index, semantic_index, chunks, model_path, root=root_path, content=content)
 
     def save(self, path: Path | str) -> None:
         """Save the index to disk."""
@@ -321,7 +324,8 @@ class SembleIndex:
             data = orjson.dumps(chunks_as_dict)
             f.write(data)
         root_str = None if self._root is None else str(self._root)
-        metadata = {"root_path": root_str, "time": datetime.now().timestamp(), "model_path": self._model_path}
+        content_strs = [ct.value for ct in self._content]
+        metadata = {"root_path": root_str, "time": datetime.now().timestamp(), "model_path": self._model_path, "content": content_strs}
         with open(persistence_paths.metadata, "wb") as f:
             data = orjson.dumps(metadata)
             f.write(data)


### PR DESCRIPTION
## Summary
- Content types are now saved to the metadata JSON during `save()`
- `load_from_disk()` restores content types from metadata, falling back to `[ContentType.CODE]` for backward compatibility with old indexes

## Problem
When saving an index with `save()`, the content types used during indexing (e.g., `CODE`, `DOCS`, `CONFIG`) were not persisted in the metadata file. When loading the same index with `load_from_disk()`, the content types always defaulted to `_DEFAULT_CONTENT = (ContentType.CODE,)`.

This caused incorrect search behavior: `search()` uses `self._content` to decide whether to apply code-tuned reranking (`resolved_rerank = ContentType.CODE in self._content`). An index built with `--content all` would lose its content type information after a save/load cycle, resulting in incorrect reranking settings.

## Test plan
- [x] Existing tests pass
- [x] Backward compatible: old indexes without `content` in metadata will default to `[ContentType.CODE]`
- [x] New indexes will correctly persist and restore content types

🤖 Generated with [Claude Code](https://claude.com/claude-code)