### PR TITLE
Log errors when file watcher stops unexpectedly

### DIFF
--- a/src/semble/mcp.py
+++ b/src/semble/mcp.py
@@ -191,7 +191,7 @@ class _IndexCache:
                 except Exception:
                     logger.warning("Failed to rebuild index for %r after file change", path, exc_info=True)
         except Exception:
-            pass
+            logger.warning("File watcher for %r stopped unexpectedly", path, exc_info=True)
 
     async def get(self, source: str, ref: str | None = None) -> SembleIndex:
         """Return an index for the requested source, building and caching it on first access."""


### PR DESCRIPTION
## Summary
- Changed the outer except Exception: pass in _watch_loop to log a warning with traceback instead of silently swallowing errors

## Problem
The _watch_loop method had a bare except Exception: pass wrapping watchfiles.awatch(). If the watcher failed for any reason (deleted directory, permission errors, OS resource limits), it would silently stop with no indication. This made debugging production issues very difficult.

## Test plan
- [x] Existing tests pass
- [x] The change only replaces pass with a logger.warning() call

🤖 Generated with [Claude Code](https://claude.com/claude-code)