### PR TITLE
Add --content support to index subcommand

### DIFF
--- a/src/semble/cli.py
+++ b/src/semble/cli.py
@@ -83,12 +83,12 @@ def _mcp_main() -> None:
     asyncio.run(serve(args.path, ref=args.ref, content=content))
 
 
-def _run_index(*, path: str, include_text_files: bool = False, out: str) -> None:
+def _run_index(*, path: str, content: list[ContentType], out: str) -> None:
     """Index and store a codebase."""
     if is_git_url(path):
-        index = SembleIndex.from_git(path, include_text_files=include_text_files)
+        index = SembleIndex.from_git(path, content=content)
     else:
-        index = SembleIndex.from_path(path, include_text_files=include_text_files)
+        index = SembleIndex.from_path(path, content=content)
     Path(out).mkdir(parents=True, exist_ok=True)
     index.save(out)
 
@@ -124,11 +124,7 @@ def _cli_main() -> None:
 
     index_p = sub.add_parser("index", help="Index and store a codebase.")
     index_p.add_argument("path", nargs="?", default=".", help="Local path or git URL (default: current directory).")
-    index_p.add_argument(
-        "--include-text-files",
-        action="store_true",
-        help="Also index non-code text files (.md, .yaml, .json, etc.).",
-    )
+    _add_content_args(index_p)
     index_p.add_argument("-o", "--out", type=str, required=True, help="The path to write the pre-built index to.")
 
     search_p = sub.add_parser("search", help="Search a codebase.")
@@ -166,7 +162,8 @@ def _cli_main() -> None:
         return
 
     if args.command == "index":
-        _run_index(path=args.path, include_text_files=args.include_text_files, out=args.out)
+        content = _resolve_content(args.content, args.include_text_files)
+        _run_index(path=args.path, content=content, out=args.out)
         return
 
     if args.command == "savings":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -200,10 +200,21 @@ def test_run_index(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     out_dir = tmp_path / "index_output"
     fake_index = MagicMock()
     with patch("semble.cli.SembleIndex.from_path", return_value=fake_index) as mock_from_path:
-        _run_index(path="/some/path", include_text_files=True, out=str(out_dir))
-    mock_from_path.assert_called_once_with("/some/path", include_text_files=True)
+        _run_index(path="/some/path", content=[ContentType.CODE, ContentType.DOCS], out=str(out_dir))
+    mock_from_path.assert_called_once_with("/some/path", content=[ContentType.CODE, ContentType.DOCS])
     assert out_dir.exists()
     fake_index.save.assert_called_once_with(str(out_dir))
+
+
+def test_index_via_cli_with_content(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """_cli_main index subcommand passes --content to from_path."""
+    out_dir = tmp_path / "built_index"
+    fake_index = MagicMock()
+    monkeypatch.setattr(sys, "argv", ["semble", "index", "/some/path", "--content", "code", "docs", "-o", str(out_dir)])
+    with patch("semble.cli.SembleIndex.from_path", return_value=fake_index) as mock_from_path:
+        _cli_main()
+    mock_from_path.assert_called_once()
+    assert mock_from_path.call_args.kwargs["content"] == [ContentType.CODE, ContentType.DOCS]
 
 
 def test_index_via_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Replaces the deprecated --include-text-files flag on the index subcommand with the modern --content argument
- Updated _run_index to accept content types directly
- Added test for --content with the index subcommand

## Problem
The index subcommand only supported the deprecated --include-text-files flag, while search and find-related subcommands already had the modern --content argument.

## Test plan
- [x] Updated existing test_run_index to use new signature
- [x] Added test_index_via_cli_with_content for --content support
- [x] Existing tests for index CLI still pass

🤖 Generated with [Claude Code