### PR TITLE
docs: Update docs, add acknowledgements

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ pip install --upgrade semble   # with pip
 
 ## MCP Server
 
-Semble can run as an MCP server so agents can search any codebase directly. Repos are cloned and indexed on demand, and indexes are cached for the lifetime of the session. Local paths are watched for file changes and re-indexed automatically.
+Semble can run as an MCP server so agents can search any codebase directly. Repos are cloned and indexed on demand. Indexes are persisted to the OS cache folder and reused across sessions; local paths are watched for file changes and re-indexed automatically.
 
 ### Setup
 
@@ -481,7 +481,7 @@ Indexes are cached to disk automatically on the first search. On subsequent runs
 
 ## Acknowledgements
 
-Thanks to [Greptile](https://greptile.com) for providing free access to their AI code review platform for open-source projects.
+Thanks to [Greptile](https://greptile.com) for providing free access to their AI code review platform.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ claude mcp add semble -s user -- uvx --from "semble[mcp]" semble
 
 See [MCP Server](#mcp-server) below for other harnesses (Cursor, Codex, OpenCode, etc.).
 
+<a id="agentsmd"></a>
+
 ### AGENTS.md
 
 Add Semble usage instructions to your agent's context so it knows when and how to call the CLI. Install the Semble CLI, then add the snippet below to your `AGENTS.md` or `CLAUDE.md`:
@@ -315,55 +317,7 @@ Add to `~/.config/zed/settings.json` (or `.zed/settings.json` in your project):
 By default the MCP server indexes only code files. To also index documentation, config, or everything, append `--content docs`, `--content config`, or `--content all` to the server command, or a combination, e.g. `--content code docs`. For example, in Claude Code: `claude mcp add semble -s user -- uvx --from "semble[mcp]" semble --content all`.
 
 
-<a id="bash-agentsmd"></a>
-
-## Bash / AGENTS.md
-
-An alternative to MCP is to invoke Semble via Bash. Sub-agents cannot call MCP tools directly, so this is the only option for sub-agent support; it can also be used alongside MCP for the top-level agent.
-
-To add Bash support, append the following to your `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, or equivalent:
-
-```markdown
-## Code Search
-
-Use `semble search` to find code by describing what it does or naming a symbol/identifier, instead of grep:
-
-​```bash
-semble search "authentication flow" ./my-project
-semble search "save_pretrained" ./my-project
-semble search "save model to disk" ./my-project --top-k 10
-​```
-
-The index is built on first run (and cached for subsequent runs) and invalidated automatically when files change.
-
-Use `--content docs` to search documentation and prose, `--content config` for config files (yaml, toml, etc.), or `--content all` to search code, docs, and config:
-
-​```bash
-semble search "deployment guide" ./my-project --content docs
-semble search "database host port" ./my-project --content config
-semble search "authentication" ./my-project --content all
-​```
-
-Use `semble find-related` to discover code similar to a known location (pass `file_path` and `line` from a prior search result):
-
-​```bash
-semble find-related src/auth.py 42 ./my-project
-​```
-
-`path` defaults to the current directory when omitted; git URLs are accepted.
-
-If `semble` is not on `$PATH`, use `uvx --from "semble[mcp]" semble` in its place.
-
-### Workflow
-
-1. Start with `semble search` to find relevant chunks. The index is built and cached automatically.
-2. Use `--content docs` for documentation, `--content config` for config files, or `--content all` for everything.
-3. Inspect full files only when the returned chunk does not give enough context.
-4. Optionally use `semble find-related` with a promising result's `file_path` and `line` to discover related implementations.
-5. Use grep only when you need exhaustive literal matches or quick confirmation of an exact string.
-```
-
-### Sub-agent setup
+## Sub-agent setup
 
 Claude Code, Gemini CLI, Cursor, OpenCode, GitHub Copilot CLI, and Kiro all support a dedicated semble search sub-agent. Run `semble init` once in your project root:
 

--- a/README.md
+++ b/README.md
@@ -477,6 +477,12 @@ After fusing, results are reranked with a set of code-aware signals:
 
 Because the embedding model is static with no transformer forward pass at query time, all of this runs in milliseconds on CPU.
 
+Indexes are cached to disk automatically on the first search. On subsequent runs, Semble walks the file tree and compares modification times; if any file was added, removed, or changed, the index is fully rebuilt. In MCP mode, a file watcher detects changes and triggers a rebuild automatically so the index is always current within the same session.
+
+## Acknowledgements
+
+Thanks to [Greptile](https://greptile.com) for providing free access to their AI code review platform for open-source projects.
+
 ## License
 
 MIT


### PR DESCRIPTION
A few docs changes from https://github.com/MinishLab/semble/pull/157 were lost, this PR restores them. Also added an acknowledgements section thanking Greptile for their free access to their platform. Lastly, added a bit more info on caching/invalidation to the how it works section (see https://github.com/MinishLab/semble/issues/163). 