### PR TITLE
fix: mismatch in roundtrip

### DIFF
--- a/src/semble/index/index.py
+++ b/src/semble/index/index.py
@@ -307,9 +307,9 @@ class SembleIndex:
 
         bm_25_index = BM25.load(persistence_paths.bm25_index)
         semantic_index = SelectableBasicBackend.load(persistence_paths.semantic_index)
-        with open(persistence_paths.metadata, "r") as f:
+        with open(persistence_paths.metadata, "rb") as f:
             metadata = orjson.loads(f.read())
-        with open(persistence_paths.chunks, "r") as f:
+        with open(persistence_paths.chunks, "rb") as f:
             chunk_data = orjson.loads(f.read())
 
         chunks = []

--- a/src/semble/version.py
+++ b/src/semble/version.py
@@ -1,2 +1,2 @@
-__version_triple__ = (0, 3, 0)
+__version_triple__ = (0, 3, 1)
 __version__ = ".".join(map(str, __version_triple__))


### PR DESCRIPTION
We stored bytes but read them as non-bytes. This is fine for most code, since code is often just ASCII, but would crash on non-ascii 

closes #167 