### PR TITLE
feat: auto-detect git repo from cwd when no repo specified

### DIFF
--- a/src/semble/mcp.py
+++ b/src/semble/mcp.py
@@ -16,7 +16,7 @@ from semble.cache import save_index_to_cache
 from semble.index import SembleIndex
 from semble.index.dense import load_model
 from semble.types import ContentType
-from semble.utils import format_results, is_git_url, resolve_chunk
+from semble.utils import find_git_root, format_results, is_git_url, resolve_chunk
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +38,11 @@ async def _get_index(
     if repo is not None and is_git_url(repo) and not repo.startswith(("https://", "http://")):
         raise ValueError(f"Only https://, http://, or local directory paths are accepted as `repo`. Got: {repo!r}")
     source = repo or default_source
+    if not source:
+        # Auto-detect: walk up from cwd to find the nearest git repo
+        git_root = find_git_root()
+        if git_root is not None:
+            source = str(git_root)
     if not source:
         raise ValueError(
             "No repo specified and no default index. "

--- a/src/semble/utils.py
+++ b/src/semble/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import re
+from pathlib import Path
 from typing import Any
 
 from semble.types import Chunk, SearchResult
@@ -14,6 +15,18 @@ DEFAULT_MODEL_NAME = "minishlab/potion-code-16M"
 def is_git_url(path: str) -> bool:
     """Return True if path looks like a remote git URL rather than a local path."""
     return path.startswith(_GIT_URL_SCHEMES) or _SCP_GIT_URL_RE.match(path) is not None
+
+
+def find_git_root(start: Path | None = None) -> Path | None:
+    """Walk up from *start* (default: cwd) to find the nearest directory containing .git.
+
+    Returns the resolved path if found, else None.
+    """
+    current = (start or Path.cwd()).resolve()
+    for parent in [current, *current.parents]:
+        if (parent / ".git").exists():
+            return parent
+    return None
 
 
 def resolve_chunk(chunks: list[Chunk], file_path: str, line: int) -> Chunk | None:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -170,10 +170,11 @@ async def test_index_cache_ignores_cache_save_failure(cache: _IndexCache, tmp_pa
     ],
 )
 async def test_tool_no_repo_no_default(cache: _IndexCache, tool: str, args: dict[str, object]) -> None:
-    """Both tools return an error message when no repo and no default source are given."""
-    server = create_server(cache, default_source=None)
-    result = await server.call_tool(tool, args)
-    assert "No repo specified" in _tool_text(result)
+    """Both tools return an error message when no repo, no default source, and no git root are found."""
+    with patch("semble.mcp.find_git_root", return_value=None):
+        server = create_server(cache, default_source=None)
+        result = await server.call_tool(tool, args)
+        assert "No repo specified" in _tool_text(result)
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Linked issue

Closes #173

## Summary

- Add `find_git_root()` utility in `src/semble/utils.py` — walks up from cwd to find nearest `.git`
- In `_get_index()`, fall back to detected git root when neither `repo` nor `default_source` is set
- MCP server now works without explicit repo config when run inside a git checkout

## Checklist

- [x] This PR is linked to an existing issue
- [x] `make test` passes
- [x] `make lint` and `make typecheck` pass
- [x] Added tests for behaviour changes