### PR TITLE
fix: disallow relative paths in user-supplied cache dir

### DIFF
--- a/src/semble/cache.py
+++ b/src/semble/cache.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import logging
 import os
 import shutil
 import sys
@@ -12,6 +13,8 @@ from semble.index.files import FileStatus, get_extensions, get_file_status
 from semble.index.types import PersistencePath
 from semble.types import ContentType
 from semble.utils import is_git_url, resolve_model_name
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from semble.index import SembleIndex
@@ -48,11 +51,24 @@ def _linux_cache_dir(name: str) -> Path:
     return base / name
 
 
+def _get_valid_user_cache_dir() -> Path | None:
+    """Gets the user cache dir if it is set and is a valid path."""
+    user_cache_location = os.getenv("SEMBLE_CACHE_LOCATION")
+    if user_cache_location is None:
+        return None
+    user_cache_dir = Path(user_cache_location)
+    if not user_cache_dir.is_absolute():
+        logger.warning("SEMBLE_CACHE_LOCATION is not an absolute path: %s", user_cache_location)
+        return None
+
+    return user_cache_dir
+
+
 def resolve_cache_folder() -> Path:
     """Resolves a cache folder, respects SEMBLE_CACHE_LOCATION (highest precedence), XDG_CACHE_HOME."""
     name = "semble"
-    if semble_cache_location := os.getenv("SEMBLE_CACHE_LOCATION"):
-        cache_dir = Path(semble_cache_location)
+    if user_cache_dir := _get_valid_user_cache_dir():
+        cache_dir = user_cache_dir
     elif sys.platform == "win32":
         cache_dir = _windows_cache_dir(name)
     elif sys.platform == "darwin":

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -97,7 +97,9 @@ def test_resolve_cache_folder(platform: str, mock_target: str, expected: Path) -
 def test_get_valid_user_cache_dir_relative_path() -> None:
     """_get_valid_user_cache_dir returns None when SEMBLE_CACHE_LOCATION is a relative path."""
     with patch.dict("os.environ", {"SEMBLE_CACHE_LOCATION": "relative/path"}):
-        assert _get_valid_user_cache_dir() is None
+        with patch("semble.cache.logger") as mock_logger:
+            assert _get_valid_user_cache_dir() is None
+        mock_logger.warning.assert_called_once()
 
 
 def test_resolve_cache_folder_semble_cache_location(tmp_path: Path) -> None:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from semble.cache import (
+    _get_valid_user_cache_dir,
     _linux_cache_dir,
     _windows_cache_dir,
     clear_cache,
@@ -91,6 +92,12 @@ def test_resolve_cache_folder(platform: str, mock_target: str, expected: Path) -
                 result = resolve_cache_folder()
     mock_fn.assert_called_once_with("semble")
     assert result == expected
+
+
+def test_get_valid_user_cache_dir_relative_path() -> None:
+    """_get_valid_user_cache_dir returns None when SEMBLE_CACHE_LOCATION is a relative path."""
+    with patch.dict("os.environ", {"SEMBLE_CACHE_LOCATION": "relative/path"}):
+        assert _get_valid_user_cache_dir() is None
 
 
 def test_resolve_cache_folder_semble_cache_location(tmp_path: Path) -> None:


### PR DESCRIPTION
This PR disallows relative paths as part of the user-supplied cache dir strategy. If the user supplies a  relative path, we revert to the default index, and show a warning.