### PR TITLE
feat: index extensionless scripts by shebang

### DIFF
--- a/src/semble/cache.py
+++ b/src/semble/cache.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from semble.index.file_walker import walk_files
-from semble.index.files import FileStatus, get_extensions, get_file_status
+from semble.index.files import FileStatus, get_extensions, get_file_status, get_shebang_languages
 from semble.index.types import PersistencePath
 from semble.types import ContentType
 from semble.utils import is_git_url, resolve_model_name
@@ -124,11 +124,12 @@ def get_validated_cache(path: str, model_path: str | None, content: Sequence[Con
 
     write_time = metadata["time"]
     extensions = get_extensions(content)
+    shebang_languages = get_shebang_languages(content)
 
     path_as_path = Path(path).resolve()
     stored_files: list[str] = metadata.get("file_paths", [])
     current_files = []
-    for file_path in walk_files(path_as_path, extensions=extensions):
+    for file_path in walk_files(path_as_path, extensions=extensions, shebang_languages=shebang_languages):
         file_status = get_file_status(file_path, write_time)
         if file_status == FileStatus.NEWER:
             return None

--- a/src/semble/index/create.py
+++ b/src/semble/index/create.py
@@ -9,7 +9,15 @@ from vicinity.backends.basic import BasicArgs
 from semble.chunking import chunk_source
 from semble.index.dense import SelectableBasicBackend, embed_chunks
 from semble.index.file_walker import walk_files
-from semble.index.files import FileStatus, detect_language, get_extensions, get_file_status, read_file_text
+from semble.index.files import (
+    FileStatus,
+    detect_language,
+    detect_language_from_shebang,
+    get_extensions,
+    get_file_status,
+    get_shebang_languages,
+    read_file_text,
+)
 from semble.index.sparse import enrich_for_bm25
 from semble.tokens import tokenize
 from semble.types import Chunk, ContentType
@@ -33,13 +41,14 @@ def create_index_from_path(
     chunks: list[Chunk] = []
     normalized = (content,) if isinstance(content, ContentType) else content
     resolved_extensions = get_extensions(normalized)
-    for file_path in walk_files(path, resolved_extensions):
-        language = detect_language(file_path)
+    shebang_languages = get_shebang_languages(normalized)
+    for file_path in walk_files(path, resolved_extensions, shebang_languages=shebang_languages):
         with contextlib.suppress(OSError):
             file_status = get_file_status(file_path, None)
             if file_status != FileStatus.VALID:
                 continue
             source = read_file_text(file_path)
+            language = detect_language(file_path) or detect_language_from_shebang(source)
             chunk_path = file_path.relative_to(display_root) if display_root else file_path
             chunks.extend(chunk_source(source, str(chunk_path), language))
 

--- a/src/semble/index/file_walker.py
+++ b/src/semble/index/file_walker.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 from pathspec import GitIgnoreSpec
 
+from semble.index.files import shebang_language_for_file
+
 
 @dataclass(frozen=True)
 class IgnoreSpec:
@@ -49,7 +51,12 @@ def _load_ignore_for_dir(directory: Path) -> GitIgnoreSpec | None:
     return None
 
 
-def walk_files(root: Path, extensions: Sequence[str], ignore: Sequence[str] | None = None) -> Iterator[Path]:
+def walk_files(
+    root: Path,
+    extensions: Sequence[str],
+    ignore: Sequence[str] | None = None,
+    shebang_languages: Sequence[str] = (),
+) -> Iterator[Path]:
     """Yield files under root matching extensions, skipping ignored paths.
 
     Directories matching DEFAULT_IGNORED_DIRS plus any names in ignore are always
@@ -58,6 +65,9 @@ def walk_files(root: Path, extensions: Sequence[str], ignore: Sequence[str] | No
     :param root: Root directory to walk.
     :param extensions: List of file extensions to match.
     :param ignore: Additional patterns to ignore.
+    :param shebang_languages: When non-empty, extensionless files whose shebang
+        maps to one of these languages are also yielded (e.g. a bin/ CLI with
+        ``#!/usr/bin/env python3``).
     :yield: Path to each file under root matching the criteria.
     :ytype: Path
     """
@@ -65,7 +75,7 @@ def walk_files(root: Path, extensions: Sequence[str], ignore: Sequence[str] | No
     dir_patterns = list(sorted(_DEFAULT_IGNORED_DIRS)) + list(ignore or [])
     base_spec = GitIgnoreSpec.from_lines(dir_patterns, backend="simple")
     s = IgnoreSpec(base=root, spec=base_spec)
-    yield from _walk(root, [s], extensions_set)
+    yield from _walk(root, [s], extensions_set, frozenset(shebang_languages))
 
 
 def _is_ignored(path: Path, specs: list[IgnoreSpec]) -> tuple[bool, bool]:
@@ -108,6 +118,7 @@ def _walk(
     directory: Path,
     inherited_specs: list[IgnoreSpec],
     extensions: frozenset[str],
+    shebang_languages: frozenset[str] = frozenset(),
 ) -> Iterator[Path]:
     """Recursive function for walking files under a directory."""
     spec = _load_ignore_for_dir(directory)
@@ -126,6 +137,12 @@ def _walk(
             continue
 
         if item.is_dir():
-            yield from _walk(item, inherited_specs, extensions)
-        elif item.is_file() and (found or item.suffix.lower() in extensions):
-            yield item
+            yield from _walk(item, inherited_specs, extensions, shebang_languages)
+        elif item.is_file():
+            if found or item.suffix.lower() in extensions:
+                yield item
+            # Fall back to shebang detection for extensionless scripts (e.g. a
+            # bin/ CLI starting with `#!/usr/bin/env python3`) when their
+            # language is one of the requested content types.
+            elif shebang_languages and not item.suffix and shebang_language_for_file(item) in shebang_languages:
+                yield item

--- a/src/semble/index/files.py
+++ b/src/semble/index/files.py
@@ -1,7 +1,8 @@
+import re
 from collections import defaultdict
 from collections.abc import Sequence
 from enum import Enum
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 from semble.types import ContentType
 
@@ -439,6 +440,38 @@ _DATA_LANGUAGES = {
     "tsv",
 }
 
+# Interpreter basename (lower-cased, version suffix stripped) -> language, used
+# to classify extensionless scripts by their shebang line when there is no file
+# extension to key on. Values must be languages present in
+# _EXTENSION_TO_LANGUAGE so the chunker can parse them.
+_SHEBANG_INTERPRETER_TO_LANGUAGE: dict[str, str] = {
+    "python": "python",
+    "bash": "bash",
+    "sh": "bash",
+    "dash": "bash",
+    "ksh": "bash",
+    "ash": "bash",
+    "zsh": "zsh",
+    "fish": "fish",
+    "node": "javascript",
+    "nodejs": "javascript",
+    "bun": "javascript",
+    "deno": "typescript",
+    "ruby": "ruby",
+    "perl": "perl",
+    "php": "php",
+    "lua": "lua",
+    "luajit": "lua",
+    "rscript": "r",
+    "pwsh": "powershell",
+    "powershell": "powershell",
+    "tclsh": "tcl",
+    "wish": "tcl",
+    "awk": "awk",
+    "gawk": "awk",
+    "groovy": "groovy",
+}
+
 
 def _inv_mapping(mapping: dict[str, str]) -> dict[str, list[str]]:
     """Invert a mapping, taking into account duplicate values."""
@@ -474,6 +507,60 @@ def get_extensions(types: Sequence[ContentType]) -> list[str]:
         all_extensions.update(_LANGUAGE_TO_EXTENSION.get(language, set()))
 
     return sorted(all_extensions)
+
+
+_SHEBANG_VERSION_SUFFIX = re.compile(r"[0-9][0-9.]*$")
+_SHEBANG_PEEK_BYTES = 256
+
+
+def detect_language_from_shebang(text: str) -> str | None:
+    """Detect a language from a script's shebang line, if present.
+
+    Handles plain interpreters (``#!/bin/bash``), ``env`` indirection
+    (``#!/usr/bin/env python3``) and ``env -S`` launcher wrappers
+    (``#!/usr/bin/env -S uv run --quiet python3``). The interpreter is taken to
+    be the last shebang token whose basename maps to a known language, so
+    wrapper commands (``env``, ``uv``, ``run``) and flags are skipped.
+
+    :param text: The file's text, or at least its first line.
+    :return: The detected language, or None when there is no usable shebang.
+    """
+    first_line = text.split("\n", 1)[0]
+    if not first_line.startswith("#!"):
+        return None
+    language: str | None = None
+    for token in first_line[2:].split():
+        if token.startswith("-"):
+            continue
+        name = PurePosixPath(token.strip("'\"")).name.lower()
+        mapped = _SHEBANG_INTERPRETER_TO_LANGUAGE.get(name) or _SHEBANG_INTERPRETER_TO_LANGUAGE.get(
+            _SHEBANG_VERSION_SUFFIX.sub("", name)
+        )
+        if mapped is not None:
+            language = mapped
+    return language
+
+
+def get_shebang_languages(types: Sequence[ContentType]) -> frozenset[str]:
+    """Languages reachable via a shebang that fall under the requested content types.
+
+    Used to gate shebang-based inclusion of extensionless scripts so it honours
+    the same content-type selection as extension-based indexing.
+    """
+    languages: set[str] = set()
+    for content_type in types:
+        languages.update(_CONTENT_TYPE_LANGUAGES[content_type])
+    return frozenset(languages & set(_SHEBANG_INTERPRETER_TO_LANGUAGE.values()))
+
+
+def shebang_language_for_file(file_path: Path) -> str | None:
+    """Read a file's first line and detect its language from the shebang, if any."""
+    try:
+        with file_path.open("r", encoding="utf-8", errors="ignore") as handle:
+            first_line = handle.readline(_SHEBANG_PEEK_BYTES)
+    except OSError:
+        return None
+    return detect_language_from_shebang(first_line)
 
 
 class FileStatus(str, Enum):

--- a/tests/test_file_walker.py
+++ b/tests/test_file_walker.py
@@ -169,3 +169,32 @@ def test_walk_files_skips_symlinks(tmp_path: Path) -> None:
     # Symlink-based paths are absent
     assert "wrapper/src/linked/mod.py" not in found
     assert "link_to_original.py" not in found
+
+
+def test_walk_files_includes_shebang_scripts(tmp_path: Path) -> None:
+    """Extensionless scripts are yielded when their shebang language is requested."""
+    _touch(tmp_path / "bin" / "run-py", "#!/usr/bin/env -S uv run python3\nprint('hi')\n")
+    _touch(tmp_path / "bin" / "run-sh", "#!/usr/bin/env bash\necho hi\n")
+    _touch(tmp_path / "bin" / "run-rb", "#!/usr/bin/env ruby\nputs 1\n")
+    _touch(tmp_path / "bin" / "notes", "just text, no shebang\n")
+    _touch(tmp_path / "src" / "a.py")
+
+    found = {
+        p.relative_to(tmp_path).as_posix()
+        for p in walk_files(tmp_path, [".py"], shebang_languages=frozenset({"python", "bash"}))
+    }
+
+    assert found == {"src/a.py", "bin/run-py", "bin/run-sh"}
+    # ruby is not in the requested shebang languages; the plain file has no shebang.
+    assert "bin/run-rb" not in found
+    assert "bin/notes" not in found
+
+
+def test_walk_files_without_shebang_languages_excludes_extensionless(tmp_path: Path) -> None:
+    """Default behaviour is unchanged: without shebang_languages, extensionless files are skipped."""
+    _touch(tmp_path / "bin" / "run-py", "#!/usr/bin/env python3\nprint('hi')\n")
+    _touch(tmp_path / "src" / "a.py")
+
+    found = {p.relative_to(tmp_path).as_posix() for p in walk_files(tmp_path, [".py"])}
+
+    assert found == {"src/a.py"}

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -8,7 +8,9 @@ from semble.index.files import (
     _DATA_LANGUAGES,
     _DOC_LANGUAGES,
     detect_language,
+    detect_language_from_shebang,
     get_extensions,
+    get_shebang_languages,
 )
 from semble.types import ContentType
 
@@ -53,3 +55,34 @@ def test_all_excludes_data_extensions() -> None:
     all_exts = set(get_extensions(list(ContentType)))
     for ext in (".csv", ".tsv", ".psv", ".json", ".json5"):
         assert ext not in all_exts, f"{ext} should not be indexed by 'all'"
+
+
+@pytest.mark.parametrize(
+    ("first_line", "expected"),
+    [
+        # env -S launcher wrapper: the real interpreter is the last mapped token.
+        ("#!/usr/bin/env -S uv run --no-project --quiet python3", "python"),
+        ("#!/usr/bin/env python3.12", "python"),
+        ("#!/usr/bin/env bash", "bash"),
+        ("#!/bin/sh", "bash"),
+        ("#!/usr/bin/perl -w", "perl"),
+        ("#!/usr/bin/env node", "javascript"),
+        ("#!/usr/bin/env -S deno run --allow-net", "typescript"),
+        ("#!/usr/bin/env Rscript", "r"),
+        ("# not a shebang", None),
+        ("", None),
+        # A shebang only counts on the first line.
+        ("plain text\n#!/bin/bash", None),
+    ],
+)
+def test_detect_language_from_shebang(first_line: str, expected: str | None) -> None:
+    """Shebang lines resolve to the interpreter language, ignoring env/launcher wrappers and flags."""
+    assert detect_language_from_shebang(first_line) == expected
+
+
+def test_get_shebang_languages() -> None:
+    """Shebang languages are gated by content type and limited to interpreter-backed languages."""
+    code = get_shebang_languages([ContentType.CODE])
+    assert {"python", "bash"} <= code
+    assert "markdown" not in code  # a docs language, never shebang-reachable
+    assert get_shebang_languages([ContentType.DOCS]) == frozenset()


### PR DESCRIPTION
## Problem

Semble decides what to index purely from the file **extension** — `walk_files`/`_walk` gate on `item.suffix`, and `detect_language` keys on `Path.suffix`. Extensionless executables are therefore never indexed, even though their content is ordinary code: a `bin/` CLI starting with `#!/usr/bin/env python3`, a `#!/usr/bin/env bash` helper, etc.

This is common in real repos — a tree I was searching had ~200 extensionless scripts under `bin/` (Python and bash), none of which semble could surface. Existing escape hatches don't cover it:

- `--content all` only widens the docs/config **extension** sets; it doesn't relax the extension requirement.
- A `.sembleignore` negation can't whitelist them either — the bypass in `_is_ignored` requires the pattern to have a suffix.

## Change

An opt-in shebang fallback, off by default:

- **`detect_language_from_shebang(text)`** (`index/files.py`) resolves the interpreter from a script's first line. It takes the *last* shebang token whose basename maps to a known interpreter, so it handles plain interpreters (`#!/bin/bash`), `env` indirection (`#!/usr/bin/env python3`), `env -S` launcher wrappers (`#!/usr/bin/env -S uv run --quiet python3` → `python`), version suffixes (`python3.12` → `python`), and flags.
- **`get_shebang_languages(types)`** returns the shebang-reachable languages within the requested content types, so shebang inclusion honours the same `--content` selection as extension indexing (`--content docs` → no scripts).
- **`walk_files()` / `_walk()`** gain an opt-in `shebang_languages` parameter; extensionless files whose shebang maps to one of those languages are also yielded. **The default is empty, so existing behaviour is unchanged.**
- **`create.py`** passes the shebang languages and uses `detect_language(path) or detect_language_from_shebang(source)`, so the file is chunked with the right grammar (line-chunking fallback otherwise, as today).
- **`cache.py`** passes the same `shebang_languages` in its cache-validation walk, so `current_files` matches the build walk and the incremental cache doesn't invalidate on every run.

Only extensionless files are probed (a bounded 256-byte first-line read), so there's no extra I/O for files that already carry a non-indexed extension. Symlinks remain skipped.

## Tests

- `tests/test_files.py`: `detect_language_from_shebang` across `env` / `env -S` / version-suffix / flag / non-shebang cases, plus `get_shebang_languages` content-type gating.
- `tests/test_file_walker.py`: extensionless scripts are included when their language is requested, excluded when it isn't, and the unchanged default (no `shebang_languages` → extensionless skipped).

Full suite: `280 passed`.

## Before / after

In a repo with extensionless `bin/` scripts, a natural-language query whose best match lives in such a script previously returned only unrelated *extensioned* files; with this change the script itself is indexed and ranks as expected, and sibling `bin/` scripts become searchable too.
