### PR TITLE
fix: Prevent concurrent write corruption in savings.jsonl

### DIFF
--- a/src/semble/stats.py
+++ b/src/semble/stats.py
@@ -59,8 +59,15 @@ def save_search_stats(
         stats_file = _get_stats_file()
         stats_file.parent.mkdir(parents=True, exist_ok=True)
         with stats_file.open("a") as f:
+            try:
+                import fcntl
+            except ImportError:
+                pass  # Windows has no fcntl, proceed without lock
+            else:
+                fcntl.flock(f, fcntl.LOCK_EX)
             f.write(json.dumps(record) + "\n")
     except OSError:
+        # If we can't write to the stats file, just skip the stats for this call
         pass
 
 

--- a/src/semble/stats.py
+++ b/src/semble/stats.py
@@ -62,12 +62,11 @@ def save_search_stats(
             try:
                 import fcntl
 
-                fcntl.flock(f, fcntl.LOCK_EX)
-            except (ImportError, OSError):  # pragma: no cover
-                pass  # Locking unavailable or failed; proceed without it
+                fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except (ImportError, OSError):
+                return  # Cannot safely acquire lock; skip stats for this call
             f.write(json.dumps(record) + "\n")
     except OSError:
-        # If we can't write to the stats file, just skip the stats for this call
         pass
 
 

--- a/src/semble/stats.py
+++ b/src/semble/stats.py
@@ -63,8 +63,10 @@ def save_search_stats(
                 import fcntl
 
                 fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            except (ImportError, OSError):  # pragma: no cover
-                return  # Cannot safely acquire lock; skip stats for this call
+            except ImportError:  # pragma: no cover
+                pass  # Windows has no fcntl, write unlocked
+            except OSError:  # pragma: no cover
+                return  # lock contention or unsupported filesystem; skip
             f.write(json.dumps(record) + "\n")
     except OSError:
         pass

--- a/src/semble/stats.py
+++ b/src/semble/stats.py
@@ -61,7 +61,7 @@ def save_search_stats(
         with stats_file.open("a") as f:
             try:
                 import fcntl
-            except ImportError:
+            except ImportError:  # pragma: no cover
                 pass  # Windows has no fcntl, proceed without lock
             else:
                 fcntl.flock(f, fcntl.LOCK_EX)

--- a/src/semble/stats.py
+++ b/src/semble/stats.py
@@ -3,7 +3,10 @@ import logging
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+from functools import cache
+from importlib import import_module
 from pathlib import Path
+from types import ModuleType
 
 from semble.cache import resolve_cache_folder
 from semble.types import CallType, SearchResult
@@ -37,6 +40,15 @@ class SavingsSummary:
     call_type_counts: dict[str, int]
 
 
+@cache
+def _import_fcntl() -> ModuleType | None:
+    """Return fcntl when available, otherwise None."""
+    try:
+        return import_module("fcntl")
+    except ImportError:  # pragma: no cover
+        return None
+
+
 def save_search_stats(
     results: list[SearchResult],
     call_type: CallType,
@@ -59,12 +71,12 @@ def save_search_stats(
         stats_file = _get_stats_file()
         stats_file.parent.mkdir(parents=True, exist_ok=True)
         with stats_file.open("a") as f:
+            fcntl = _import_fcntl()
             try:
-                import fcntl
-
-                fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            except ImportError:  # pragma: no cover
-                pass  # Windows has no fcntl, write unlocked
+                if fcntl is not None:
+                    fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:  # pragma: no cover
+                return  # another process holds the lock; skip this record
             except OSError:  # pragma: no cover
                 return  # lock contention or unsupported filesystem; skip
             f.write(json.dumps(record) + "\n")

--- a/src/semble/stats.py
+++ b/src/semble/stats.py
@@ -61,10 +61,10 @@ def save_search_stats(
         with stats_file.open("a") as f:
             try:
                 import fcntl
-            except ImportError:  # pragma: no cover
-                pass  # Windows has no fcntl, proceed without lock
-            else:
+
                 fcntl.flock(f, fcntl.LOCK_EX)
+            except (ImportError, OSError):  # pragma: no cover
+                pass  # Locking unavailable or failed; proceed without it
             f.write(json.dumps(record) + "\n")
     except OSError:
         # If we can't write to the stats file, just skip the stats for this call

--- a/src/semble/stats.py
+++ b/src/semble/stats.py
@@ -63,7 +63,7 @@ def save_search_stats(
                 import fcntl
 
                 fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            except (ImportError, OSError):
+            except (ImportError, OSError):  # pragma: no cover
                 return  # Cannot safely acquire lock; skip stats for this call
             f.write(json.dumps(record) + "\n")
     except OSError:

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,5 +1,6 @@
 import json
 import sys
+import types
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -25,6 +26,25 @@ def sample_stats_file(tmp_path: Path) -> Path:
         _make_stats_record(now, call="search") + "\n" + _make_stats_record(now, call="find_related") + "\n"
     )
     return stats_file
+
+
+def test_save_search_stats_skips_on_lock_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """save_search_stats silently skips the write when locking fails."""
+    chunk = make_chunk("hello", "src/foo.py")
+    result = SearchResult(chunk=chunk, score=0.9)
+    stats_file = tmp_path / "stats.jsonl"
+    stats_file.touch()
+    monkeypatch.setattr("semble.stats._get_stats_file", lambda: stats_file)
+
+    mock_fcntl = types.ModuleType("fcntl")
+    mock_fcntl.LOCK_EX = 2  # type: ignore[attr-defined]
+    mock_fcntl.LOCK_NB = 4  # type: ignore[attr-defined]
+    mock_fcntl.flock = MagicMock(side_effect=OSError)  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "fcntl", mock_fcntl)
+
+    save_search_stats([result], CallType.SEARCH, {"src/foo.py": 42})
+
+    assert stats_file.read_text() == ""
 
 
 def test_save_search_stats(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,6 +1,5 @@
 import json
 import sys
-import types
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -26,25 +25,6 @@ def sample_stats_file(tmp_path: Path) -> Path:
         _make_stats_record(now, call="search") + "\n" + _make_stats_record(now, call="find_related") + "\n"
     )
     return stats_file
-
-
-def test_save_search_stats_skips_on_lock_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """save_search_stats silently skips the write when locking fails."""
-    chunk = make_chunk("hello", "src/foo.py")
-    result = SearchResult(chunk=chunk, score=0.9)
-    stats_file = tmp_path / "stats.jsonl"
-    stats_file.touch()
-    monkeypatch.setattr("semble.stats._get_stats_file", lambda: stats_file)
-
-    mock_fcntl = types.ModuleType("fcntl")
-    mock_fcntl.LOCK_EX = 2  # type: ignore[attr-defined]
-    mock_fcntl.LOCK_NB = 4  # type: ignore[attr-defined]
-    mock_fcntl.flock = MagicMock(side_effect=OSError)  # type: ignore[attr-defined]
-    monkeypatch.setitem(sys.modules, "fcntl", mock_fcntl)
-
-    save_search_stats([result], CallType.SEARCH, {"src/foo.py": 42})
-
-    assert stats_file.read_text() == ""
 
 
 def test_save_search_stats(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 
 [options]
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P3D"
+exclude-newer-span = "P1W"
 
 [[package]]
 name = "annotated-doc"


### PR DESCRIPTION
Multiple MCP server processes appending to savings.jsonl simultaneously caused a small amount of lines to contain interleaved JSON. Added a lock for unix,  Windows can technically still write malformed lines but it won't break the CLI, just show a warning (if we want to do it for windows we need to add a dependency which I don't really want to do for this).