### PR TITLE
feat: add --version flag

### DIFF
--- a/src/semble/cli.py
+++ b/src/semble/cli.py
@@ -17,8 +17,11 @@ from semble.installer.agents import AGENTS, IntegrationType
 from semble.stats import format_savings_report
 from semble.types import ContentType
 from semble.utils import format_results, is_git_url, resolve_chunk
+from semble.version import __version__
 
-_CLI_DISPATCH_ARGS = frozenset({"search", "find-related", "install", "uninstall", "savings", "-h", "--help", "clear"})
+_CLI_DISPATCH_ARGS = frozenset(
+    {"search", "find-related", "install", "uninstall", "savings", "-h", "--help", "clear", "--version", "-V"}
+)
 _CLEAR_CHOICE = Literal["all", "index", "savings"]
 
 _SHA_256_REGEX = re.compile(r"^[a-f0-9]{64}$")
@@ -166,6 +169,7 @@ def _run_clear(clear_type: _CLEAR_CHOICE) -> None:
 
 def _cli_main() -> None:
     parser = argparse.ArgumentParser(prog="semble")
+    parser.add_argument("-V", "--version", action="version", version=__version__)
     sub = parser.add_subparsers(dest="command")
 
     search_p = sub.add_parser("search", help="Search a codebase.")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ import pytest
 
 from semble.cli import _cli_main, _maybe_save_index, _run_clear, main
 from semble.types import ContentType, SearchResult
+from semble.version import __version__
 from tests.conftest import make_chunk
 
 
@@ -87,6 +88,16 @@ def test_cli_find_related(
         assert fragment in captured.out
     if expected_stderr:
         assert expected_stderr in captured.err
+
+
+@pytest.mark.parametrize("argv", [["semble", "--version"], ["semble", "-V"]])
+def test_cli_version(argv: list[str], monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    """--version and -V print the package version and exit 0, via both _cli_main and main()."""
+    monkeypatch.setattr(sys, "argv", argv)
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == 0
+    assert capsys.readouterr().out.strip() == __version__
 
 
 def test_main_dispatches_to_cli(


### PR DESCRIPTION
This PR adds a little version flag that can be used to check whether your semble is up to date.


```
semble --version
semble -V
```

It just prints `__version__`, so not a lot going on. In the future, we can enrich this using other metadata (builds etc.)