### PR TITLE
chore: update zed mcp config

### DIFF
--- a/src/semble/installer/agents.py
+++ b/src/semble/installer/agents.py
@@ -42,8 +42,7 @@ _BARE_STDIO_SERVER_CONFIG: dict[str, object] = {  # Windsurf: command/args only,
     "args": ["--from", "semble[mcp]", "semble"],
 }
 
-_ZED_SERVER_CONFIG: dict[str, object] = {  # Zed requires "source": "custom" for manual servers
-    "source": "custom",
+_ZED_SERVER_CONFIG: dict[str, object] = {  # Zed: command/args only, no "source"
     "command": "uvx",
     "args": ["--from", "semble[mcp]", "semble"],
 }


### PR DESCRIPTION
The zed MCP config got changed recently. Whenever I installed `semble`, I would get a warning that my settings were out of date. Zed autofixed this, so nothing broke. This PR removes our outdated format and replaces it with the newer one. I tested and installing now no longer triggers the warning toast and auto-update.