### PR TITLE
fix: preserve parser load failure details

### DIFF
--- a/src/semble/chunking/core.py
+++ b/src/semble/chunking/core.py
@@ -33,10 +33,18 @@ def _cached_get_parser(language: SupportedLanguage) -> Parser | None:
     """Gets a parser from tree_sitter."""
     try:
         return get_parser(language)
-    except LanguageNotFoundError:
-        logger.warning("Language %s not found, falling back to line chunking", language)
-    except DownloadError:
-        logger.warning("Failed to download language %s, falling back to line chunking", language)
+    except LanguageNotFoundError as error:
+        logger.warning(
+            "Language %s not found (%s), falling back to line chunking",
+            language,
+            error,
+        )
+    except DownloadError as error:
+        logger.warning(
+            "Failed to download language %s (%s), falling back to line chunking",
+            language,
+            error,
+        )
     except Exception:
         logger.error("Uncaught exception in _cached_get_parser", exc_info=True)
     return None

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -2,7 +2,7 @@ import logging
 from unittest.mock import patch
 
 import pytest
-from tree_sitter_language_pack import DownloadError
+from tree_sitter_language_pack import DownloadError, LanguageNotFoundError
 
 from semble.chunking.chunking import Chunk, chunk_lines, chunk_source
 from semble.chunking.core import ChunkBoundary, _cached_get_parser, chunk
@@ -102,12 +102,14 @@ def test_get_parser(caplog: pytest.LogCaptureFixture) -> None:
         _cached_get_parser("hello")
         assert len(caplog.records) == 0
 
-    with patch("semble.chunking.core.get_parser", side_effect=DownloadError):
+    download_error = DownloadError("invalid peer certificate: UnknownIssuer")
+    with patch("semble.chunking.core.get_parser", side_effect=download_error):
         with caplog.at_level(logging.WARNING, logger="semble.chunking.core"):
             _cached_get_parser("Python")
             assert len(caplog.records) == 1
             assert "Failed to download" in caplog.records[0].message
             assert "Python" in caplog.records[0].message
+            assert "UnknownIssuer" in caplog.records[0].message
 
             caplog.clear()
             _cached_get_parser("Python")
@@ -122,6 +124,18 @@ def test_get_parser(caplog: pytest.LogCaptureFixture) -> None:
             caplog.clear()
             _cached_get_parser("Ruby")
             assert len(caplog.records) == 0
+
+
+def test_language_not_found_reports_download_failure(caplog: pytest.LogCaptureFixture) -> None:
+    """A wrapped download failure remains visible when line chunking is used."""
+    error = LanguageNotFoundError("Download error: failed to fetch parser manifest")
+
+    with patch("semble.chunking.core.get_parser", side_effect=error):
+        with caplog.at_level(logging.WARNING, logger="semble.chunking.core"):
+            assert _cached_get_parser("python") is None
+
+    assert "failed to fetch parser manifest" in caplog.records[0].message
+    assert "falling back to line chunking" in caplog.records[0].message
 
 
 def test_chunks_is_none() -> None:


### PR DESCRIPTION
## Summary

- include the underlying `LanguageNotFoundError` or `DownloadError` detail in parser fallback warnings
- keep the existing fallback to line chunking unchanged
- add regression coverage for wrapped manifest-download and certificate failures

## Why

As described in #224, `tree-sitter-language-pack` can surface a download or TLS failure as `LanguageNotFoundError`. The current warning drops the exception detail, so users only see that a language was not found and cannot identify the blocked manifest download.

This is intentionally limited to the diagnostics portion of #224; it does not change grammar packaging or add dependencies.

## Validation

- `uv run pytest tests/test_chunker.py::test_get_parser tests/test_chunker.py::test_language_not_found_reports_download_failure tests/test_chunker.py::test_download_error -q`
- `uv run ruff check src/semble/chunking/core.py tests/test_chunker.py`
- `uv run mypy src/semble/chunking/core.py`

The full `tests/test_chunker.py` run was not completed because the uncached parser tests waited on the runtime grammar download. The affected failure paths are covered with mocks above.
