### PR TITLE
Correct eleven gold annotations pointing at dead, shim, or deprecated files

### DIFF
--- a/benchmarks/annotations/aiohttp.json
+++ b/benchmarks/annotations/aiohttp.json
@@ -21,7 +21,7 @@
       "aiohttp/client_ws.py"
     ],
     "secondary": [
-      "aiohttp/_websocket/reader.py"
+      "aiohttp/_websocket/reader_py.py"
     ],
     "category": "semantic"
   },

--- a/benchmarks/annotations/model2vec.json
+++ b/benchmarks/annotations/model2vec.json
@@ -22,9 +22,7 @@
     "relevant": [
       "model2vec/tokenizer/tokenizer.py"
     ],
-    "secondary": [
-      "model2vec/distill/utils.py"
-    ],
+    "secondary": [],
     "category": "semantic"
   },
   {
@@ -122,7 +120,7 @@
   {
     "query": "how vocabulary is pruned during distillation",
     "relevant": [
-      "model2vec/distill/utils.py"
+      "model2vec/tokenizer/tokenizer.py"
     ],
     "secondary": [
       "model2vec/distill/distillation.py"

--- a/benchmarks/annotations/pydantic.json
+++ b/benchmarks/annotations/pydantic.json
@@ -31,7 +31,7 @@
       "pydantic/functional_validators.py"
     ],
     "secondary": [
-      "pydantic/class_validators.py"
+      "pydantic/deprecated/class_validators.py"
     ],
     "category": "semantic"
   },

--- a/benchmarks/annotations/vitest.json
+++ b/benchmarks/annotations/vitest.json
@@ -55,8 +55,8 @@
   },
   {
     "query": "test reporter interface for listening to test events and results",
-    "relevant": ["packages/vitest/src/public/reporters.ts"],
-    "secondary": [],
+    "relevant": ["packages/vitest/src/node/types/reporter.ts"],
+    "secondary": ["packages/vitest/src/node/reporters/index.ts"],
     "category": "semantic"
   },
   {

--- a/benchmarks/annotations/zod.json
+++ b/benchmarks/annotations/zod.json
@@ -37,20 +37,20 @@
   },
   {
     "query": "union and discriminated union schema types",
-    "relevant": ["packages/zod/src/v4/core/api.ts"],
-    "secondary": ["packages/zod/src/v4/core/schemas.ts"],
+    "relevant": ["packages/zod/src/v4/core/schemas.ts"],
+    "secondary": ["packages/zod/src/v4/classic/schemas.ts"],
     "category": "semantic"
   },
   {
     "query": "optional and nullable type wrappers",
-    "relevant": ["packages/zod/src/v4/core/api.ts"],
-    "secondary": [],
+    "relevant": ["packages/zod/src/v4/core/schemas.ts"],
+    "secondary": ["packages/zod/src/v4/classic/schemas.ts"],
     "category": "semantic"
   },
   {
     "query": "z.transform and z.pipe for chaining Zod output transformations",
-    "relevant": ["packages/zod/src/v4/core/api.ts"],
-    "secondary": [],
+    "relevant": ["packages/zod/src/v4/core/schemas.ts"],
+    "secondary": ["packages/zod/src/v4/classic/schemas.ts"],
     "category": "semantic"
   },
   {
@@ -85,20 +85,20 @@
   },
   {
     "query": "z.record and z.map schema builders for key-value types",
-    "relevant": ["packages/zod/src/v4/core/api.ts"],
-    "secondary": [],
+    "relevant": ["packages/zod/src/v4/core/schemas.ts"],
+    "secondary": ["packages/zod/src/v4/classic/schemas.ts"],
     "category": "semantic"
   },
   {
     "query": "ZodDefault and ZodCatch schema wrappers that supply fallback values on parse failure",
-    "relevant": ["packages/zod/src/v4/core/api.ts"],
-    "secondary": [],
+    "relevant": ["packages/zod/src/v4/core/schemas.ts"],
+    "secondary": ["packages/zod/src/v4/classic/schemas.ts"],
     "category": "semantic"
   },
   {
     "query": "enum schema types for literal value sets",
-    "relevant": ["packages/zod/src/v4/core/api.ts"],
-    "secondary": [],
+    "relevant": ["packages/zod/src/v4/core/schemas.ts"],
+    "secondary": ["packages/zod/src/v4/classic/schemas.ts"],
     "category": "semantic"
   },
   {


### PR DESCRIPTION
Follow-up to #257 — the corrections offered there, folded into one PR.

The benchmark scores a tool by whether it finds one specific "right answer" file for each question. For these eleven questions, the file the answer key names isn't where the behavior in the question actually lives: some of the named files hold copies of code nothing in the project calls anymore, some are small forwarding files that only point at the real implementation, and one is an entry point the project itself now warns against using. A tool that returns the genuinely useful file gets marked wrong on these; one that returns the leftover gets full credit. Each replacement below was checked by hand at the revisions pinned in `repos.json` (call-site checks and file reads — the per-line evidence is in the issue thread).

| repo | query | was | now |
|---|---|---|---|
| model2vec | how vocabulary is pruned during distillation | `distill/utils.py` (device selection only) | `tokenizer/tokenizer.py`, where `prune_added_tokens()` lives (secondary `distill/distillation.py` unchanged) |
| model2vec | tokenizer construction and vocabulary building | secondary `distill/utils.py` | secondary dropped |
| pydantic | custom field and model validators | secondary `class_validators.py` (5-line migration shim) | secondary `deprecated/class_validators.py`, the actual V1-style validators |
| aiohttp | WebSocket client implementation | secondary `_websocket/reader.py` (31-line C/Python import switch) | secondary `_websocket/reader_py.py`, the implementation it re-exports |
| vitest | test reporter interface for listening to test events and results | `public/reporters.ts` (re-export barrel, deprecated at runtime since Vitest 4.1) | `node/types/reporter.ts` (the `Reporter` interface itself), secondary `node/reporters/index.ts` |

The six zod queries (union/discriminatedUnion, optional/nullable, transform/pipe, record/map, ZodDefault/ZodCatch, enum/nativeEnum/literal) all share one pattern: `v4/core/api.ts` exports factory helpers that `classic/` and `mini/` reimplement rather than call — 49 of its 114 exported functions have no call site anywhere in the repo. Each of the six now points at `v4/core/schemas.ts` (the runtime classes that do the work) as primary, with `v4/classic/schemas.ts` (the builders users actually reach through `z.*`) as secondary.

Reran semble itself on the five affected repos before and after, same machine, scored the same way as the head-to-head in the issue:

| repo | n | before | after | Δ |
|---|---:|---:|---:|---:|
| aiohttp | 21 | 0.773 | 0.762 | −0.011 |
| model2vec | 20 | 0.716 | 0.738 | +0.022 |
| pydantic | 20 | 0.690 | 0.690 | 0.000 |
| vitest | 20 | 0.654 | 0.641 | −0.013 |
| zod | 20 | 0.558 | 0.639 | +0.081 |
| **overall** | 101 | **0.679** | **0.695** | **+0.016** |

Net positive for semble itself, mostly from zod — pointing the golds at files that actually contain the queried behavior makes them more findable for everyone. I didn't rerun the other models in the published table (as you said, they're the expensive part), so their columns will drift a little on these repos whenever they are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
