### PR TITLE
feat: Add progress bar and pretty print for CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ semble find-related src/auth.py 42 ./my-project
 semble search "authentication flow" ./my-project --max-snippet-lines 10
 ```
 
-`--content` accepts `code` (default), `docs`, `config`, or `all`. `path` defaults to the current directory when omitted; git URLs are accepted. If `semble` is not on `$PATH`, use `uvx --from "semble[mcp]" semble` in its place. `semble --version` (or `-V`) prints the installed version.
+`--content` accepts `code` (default), `docs`, `config`, or `all`. `--format` accepts `json` (default) or `text`. `path` defaults to the current directory when omitted; git URLs are accepted. If `semble` is not on `$PATH`, use `uvx --from "semble[mcp]" semble` in its place. `semble --version` (or `-V`) prints the installed version.
 
 <details>
 <summary>Controlling which files are indexed</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "orjson",
     "questionary>=2.0,<3.0",
     "semble-grammars>=0.1.2",
+    "tqdm>=4.60",
 ]
 
 [project.optional-dependencies]

--- a/src/semble/cli.py
+++ b/src/semble/cli.py
@@ -32,11 +32,11 @@ _SHA_256_REGEX = re.compile(r"^[a-f0-9]{64}$")
 
 def _build_index(path: str, content: list[ContentType]) -> SembleIndex:
     """Build an index from a local path or git URL, showing a progress bar on a tty."""
-    show_progress = sys.stderr.isatty()
+    show_progress_bar = sys.stderr.isatty()
     return (
-        SembleIndex.from_git(path, content=content, show_progress=show_progress)
+        SembleIndex.from_git(path, content=content, show_progress_bar=show_progress_bar)
         if is_git_url(path)
-        else SembleIndex.from_path(path, content=content, show_progress=show_progress)
+        else SembleIndex.from_path(path, content=content, show_progress_bar=show_progress_bar)
     )
 
 

--- a/src/semble/cli.py
+++ b/src/semble/cli.py
@@ -6,14 +6,12 @@ import logging
 import re
 import sys
 import warnings
-from collections.abc import Callable
 from importlib.util import find_spec
 from pathlib import Path
 from shutil import rmtree
 from typing import Literal
 
 from model2vec.utils import get_package_extras
-from tqdm import tqdm
 
 from semble.cache import cache_key, resolve_cache_folder, save_index_to_cache
 from semble.index import SembleIndex
@@ -32,34 +30,13 @@ _CLEAR_CHOICE = Literal["all", "index", "savings", "orphans"]
 _SHA_256_REGEX = re.compile(r"^[a-f0-9]{64}$")
 
 
-def _make_progress_callback() -> Callable[[int, int], None] | None:
-    """Return a callback that lazily shows an indexing progress bar on stderr, or None if not a tty.
-
-    The bar is only created on the first call, so a cache hit (no indexing work) never shows one.
-    """
-    if not sys.stderr.isatty():
-        return None
-    bar: tqdm | None = None
-
-    def on_progress(files_done: int, files_total: int) -> None:
-        nonlocal bar
-        if bar is None:
-            bar = tqdm(total=files_total, desc="Indexing", unit="file", file=sys.stderr, leave=False, colour="green")
-        bar.n = files_done
-        bar.refresh()
-        if files_done == files_total:
-            bar.close()
-
-    return on_progress
-
-
 def _build_index(path: str, content: list[ContentType]) -> SembleIndex:
     """Build an index from a local path or git URL, showing a progress bar on a tty."""
-    on_progress = _make_progress_callback()
+    show_progress = sys.stderr.isatty()
     return (
-        SembleIndex.from_git(path, content=content, on_progress=on_progress)
+        SembleIndex.from_git(path, content=content, show_progress=show_progress)
         if is_git_url(path)
-        else SembleIndex.from_path(path, content=content, on_progress=on_progress)
+        else SembleIndex.from_path(path, content=content, show_progress=show_progress)
     )
 
 
@@ -158,7 +135,10 @@ def _run_search(
     index = _load_index(path, content)
     results = index.search(query, top_k=top_k, max_snippet_lines=max_snippet_lines)
     out = format_results(query, results, max_snippet_lines) if results else {"error": "No results found."}
-    _print_pretty(out) if pretty else print(json.dumps(out))
+    if pretty:
+        _print_pretty(out)
+    else:
+        print(json.dumps(out))
     _maybe_save_index(index, path)
 
 
@@ -184,7 +164,10 @@ def _run_find_related(
         if results
         else {"error": f"No related chunks found for {file_path}:{line}."}
     )
-    _print_pretty(out) if pretty else print(json.dumps(out))
+    if pretty:
+        _print_pretty(out)
+    else:
+        print(json.dumps(out))
     _maybe_save_index(index, path)
 
 

--- a/src/semble/cli.py
+++ b/src/semble/cli.py
@@ -6,12 +6,14 @@ import logging
 import re
 import sys
 import warnings
+from collections.abc import Callable
 from importlib.util import find_spec
 from pathlib import Path
 from shutil import rmtree
 from typing import Literal
 
 from model2vec.utils import get_package_extras
+from tqdm import tqdm
 
 from semble.cache import cache_key, resolve_cache_folder, save_index_to_cache
 from semble.index import SembleIndex
@@ -30,12 +32,34 @@ _CLEAR_CHOICE = Literal["all", "index", "savings", "orphans"]
 _SHA_256_REGEX = re.compile(r"^[a-f0-9]{64}$")
 
 
+def _make_progress_callback() -> Callable[[int, int], None] | None:
+    """Return a callback that lazily shows an indexing progress bar on stderr, or None if not a tty.
+
+    The bar is only created on the first call, so a cache hit (no indexing work) never shows one.
+    """
+    if not sys.stderr.isatty():
+        return None
+    bar: tqdm | None = None
+
+    def on_progress(files_done: int, files_total: int) -> None:
+        nonlocal bar
+        if bar is None:
+            bar = tqdm(total=files_total, desc="Indexing", unit="file", file=sys.stderr, leave=False, colour="green")
+        bar.n = files_done
+        bar.refresh()
+        if files_done == files_total:
+            bar.close()
+
+    return on_progress
+
+
 def _build_index(path: str, content: list[ContentType]) -> SembleIndex:
-    """Build an index from a local path or git URL."""
+    """Build an index from a local path or git URL, showing a progress bar on a tty."""
+    on_progress = _make_progress_callback()
     return (
-        SembleIndex.from_git(path, content=content)
+        SembleIndex.from_git(path, content=content, on_progress=on_progress)
         if is_git_url(path)
-        else SembleIndex.from_path(path, content=content)
+        else SembleIndex.from_path(path, content=content, on_progress=on_progress)
     )
 
 
@@ -114,17 +138,38 @@ def _load_index(path: str, content: list[ContentType]) -> SembleIndex:
         sys.exit(1)
 
 
-def _run_search(path: str, query: str, top_k: int, content: list[ContentType], max_snippet_lines: int | None) -> None:
+def _print_pretty(out: dict) -> None:
+    """Print a format_results() payload as human-readable text instead of JSON."""
+    if "error" in out:
+        print(out["error"])
+        return
+    for r in out["results"]:
+        print(f"{r['file_path']}:{r['start_line']}-{r['end_line']}")
+        if "content" in r:
+            print()
+            print(r["content"])
+        print()
+
+
+def _run_search(
+    path: str, query: str, top_k: int, content: list[ContentType], max_snippet_lines: int | None, pretty: bool
+) -> None:
     """Handle the `search` subcommand."""
     index = _load_index(path, content)
     results = index.search(query, top_k=top_k, max_snippet_lines=max_snippet_lines)
     out = format_results(query, results, max_snippet_lines) if results else {"error": "No results found."}
-    print(json.dumps(out))
+    _print_pretty(out) if pretty else print(json.dumps(out))
     _maybe_save_index(index, path)
 
 
 def _run_find_related(
-    path: str, file_path: str, line: int, top_k: int, content: list[ContentType], max_snippet_lines: int | None
+    path: str,
+    file_path: str,
+    line: int,
+    top_k: int,
+    content: list[ContentType],
+    max_snippet_lines: int | None,
+    pretty: bool,
 ) -> None:
     """Handle the `find-related` subcommand."""
     index = _load_index(path, content)
@@ -139,7 +184,7 @@ def _run_find_related(
         if results
         else {"error": f"No related chunks found for {file_path}:{line}."}
     )
-    print(json.dumps(out))
+    _print_pretty(out) if pretty else print(json.dumps(out))
     _maybe_save_index(index, path)
 
 
@@ -241,6 +286,7 @@ def _cli_main() -> None:
         metavar="N",
         help="Lines of source per result (default: full chunk). 10 = signature + body, 0 = no code.",
     )
+    search_p.add_argument("--pretty", action="store_true", help="Human-readable text output instead of JSON.")
     _add_content_args(search_p)
 
     clear_p = sub.add_parser("clear", help="Clear the index cache.")
@@ -262,6 +308,7 @@ def _cli_main() -> None:
         metavar="N",
         help="Lines of source per result (default: full chunk). 10 = signature + body, 0 = no code.",
     )
+    related_p.add_argument("--pretty", action="store_true", help="Human-readable text output instead of JSON.")
     _add_content_args(related_p)
 
     sub.add_parser("savings", help="Show token savings and usage stats.")
@@ -311,6 +358,7 @@ def _cli_main() -> None:
             args.top_k,
             _resolve_content(args.content, args.include_text_files),
             args.max_snippet_lines,
+            args.pretty,
         )
     elif args.command == "find-related":
         _run_find_related(
@@ -320,4 +368,5 @@ def _cli_main() -> None:
             args.top_k,
             _resolve_content(args.content, args.include_text_files),
             args.max_snippet_lines,
+            args.pretty,
         )

--- a/src/semble/cli.py
+++ b/src/semble/cli.py
@@ -32,8 +32,7 @@ _SHA_256_REGEX = re.compile(r"^[a-f0-9]{64}$")
 
 def _build_index(path: str, content: list[ContentType]) -> SembleIndex:
     """Build an index from a local path or git URL, showing a progress bar on a tty."""
-    # Only show the bar to a human at a terminal; piped stderr (agents, scripts, 2>log) stays clean.
-    show_progress_bar = sys.stderr.isatty()
+    show_progress_bar = sys.stderr.isatty()  # Only show the progress bar in a terminal
     return (
         SembleIndex.from_git(path, content=content, show_progress_bar=show_progress_bar)
         if is_git_url(path)

--- a/src/semble/cli.py
+++ b/src/semble/cli.py
@@ -32,6 +32,7 @@ _SHA_256_REGEX = re.compile(r"^[a-f0-9]{64}$")
 
 def _build_index(path: str, content: list[ContentType]) -> SembleIndex:
     """Build an index from a local path or git URL, showing a progress bar on a tty."""
+    # Only show the bar to a human at a terminal; piped stderr (agents, scripts, 2>log) stays clean.
     show_progress_bar = sys.stderr.isatty()
     return (
         SembleIndex.from_git(path, content=content, show_progress_bar=show_progress_bar)

--- a/src/semble/cli.py
+++ b/src/semble/cli.py
@@ -115,30 +115,26 @@ def _load_index(path: str, content: list[ContentType]) -> SembleIndex:
         sys.exit(1)
 
 
-def _print_pretty(out: dict) -> None:
-    """Print a format_results() payload as human-readable text instead of JSON."""
-    if "error" in out:
+def _print_results(out: dict, output_format: str) -> None:
+    """Print a format_results() payload as JSON or as human-readable text."""
+    if output_format == "json":
+        print(json.dumps(out))
+    elif "error" in out:
         print(out["error"])
-        return
-    for r in out["results"]:
-        print(f"{r['file_path']}:{r['start_line']}-{r['end_line']}")
-        if "content" in r:
-            print()
-            print(r["content"])
-        print()
+    else:
+        for r in out["results"]:
+            snippet = f"\n\n{r['content']}" if "content" in r else ""
+            print(f"{r['file_path']}:{r['start_line']}-{r['end_line']}{snippet}\n")
 
 
 def _run_search(
-    path: str, query: str, top_k: int, content: list[ContentType], max_snippet_lines: int | None, pretty: bool
+    path: str, query: str, top_k: int, content: list[ContentType], max_snippet_lines: int | None, output_format: str
 ) -> None:
     """Handle the `search` subcommand."""
     index = _load_index(path, content)
     results = index.search(query, top_k=top_k, max_snippet_lines=max_snippet_lines)
     out = format_results(query, results, max_snippet_lines) if results else {"error": "No results found."}
-    if pretty:
-        _print_pretty(out)
-    else:
-        print(json.dumps(out))
+    _print_results(out, output_format)
     _maybe_save_index(index, path)
 
 
@@ -149,7 +145,7 @@ def _run_find_related(
     top_k: int,
     content: list[ContentType],
     max_snippet_lines: int | None,
-    pretty: bool,
+    output_format: str,
 ) -> None:
     """Handle the `find-related` subcommand."""
     index = _load_index(path, content)
@@ -164,10 +160,7 @@ def _run_find_related(
         if results
         else {"error": f"No related chunks found for {file_path}:{line}."}
     )
-    if pretty:
-        _print_pretty(out)
-    else:
-        print(json.dumps(out))
+    _print_results(out, output_format)
     _maybe_save_index(index, path)
 
 
@@ -269,7 +262,7 @@ def _cli_main() -> None:
         metavar="N",
         help="Lines of source per result (default: full chunk). 10 = signature + body, 0 = no code.",
     )
-    search_p.add_argument("--pretty", action="store_true", help="Human-readable text output instead of JSON.")
+    search_p.add_argument("--format", choices=["json", "text"], default="json", help="Output format (default: json).")
     _add_content_args(search_p)
 
     clear_p = sub.add_parser("clear", help="Clear the index cache.")
@@ -291,7 +284,7 @@ def _cli_main() -> None:
         metavar="N",
         help="Lines of source per result (default: full chunk). 10 = signature + body, 0 = no code.",
     )
-    related_p.add_argument("--pretty", action="store_true", help="Human-readable text output instead of JSON.")
+    related_p.add_argument("--format", choices=["json", "text"], default="json", help="Output format (default: json).")
     _add_content_args(related_p)
 
     sub.add_parser("savings", help="Show token savings and usage stats.")
@@ -341,7 +334,7 @@ def _cli_main() -> None:
             args.top_k,
             _resolve_content(args.content, args.include_text_files),
             args.max_snippet_lines,
-            args.pretty,
+            args.format,
         )
     elif args.command == "find-related":
         _run_find_related(
@@ -351,5 +344,5 @@ def _cli_main() -> None:
             args.top_k,
             _resolve_content(args.content, args.include_text_files),
             args.max_snippet_lines,
-            args.pretty,
+            args.format,
         )

--- a/src/semble/index/create.py
+++ b/src/semble/index/create.py
@@ -1,6 +1,6 @@
 import contextlib
 import logging
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from pathlib import Path
 
 import numpy as np
@@ -72,6 +72,7 @@ def create_index_from_path(
     content: ContentType | Sequence[ContentType] = (ContentType.CODE,),
     display_root: Path | None = None,
     previous: PreviousIndex | None = None,
+    on_progress: Callable[[int, int], None] | None = None,
 ) -> tuple[BM25, SelectableBasicBackend, list[Chunk], dict[str, FileManifestEntry]]:
     """Create an index from a resolved directory, optionally reusing a previous index's unchanged files.
 
@@ -80,6 +81,7 @@ def create_index_from_path(
     :param content: Content types to index.
     :param display_root: If set, chunk file paths are stored relative to this root.
     :param previous: A previously built index to reuse unchanged files' chunks/embeddings/postings from.
+    :param on_progress: Optional callback invoked as (files_done, files_total) after each candidate file.
     :raises ValueError: if no items were found, no index can be created.
     :return: A BM25 index, semantic index, list of chunks, and file manifest.
     """
@@ -98,7 +100,12 @@ def create_index_from_path(
 
     skipped_large: list[str] = []
 
-    for file_path in walk_files(path, resolved_extensions):
+    candidate_files = list(walk_files(path, resolved_extensions))
+    total_files = len(candidate_files)
+    report_progress = on_progress or (lambda files_done, files_total: None)
+
+    for files_done, file_path in enumerate(candidate_files, start=1):
+        report_progress(files_done, total_files)
         language = detect_language(file_path)
         with contextlib.suppress(OSError):
             file_status = get_file_status(file_path, None)

--- a/src/semble/index/create.py
+++ b/src/semble/index/create.py
@@ -74,7 +74,7 @@ def create_index_from_path(
     content: ContentType | Sequence[ContentType] = (ContentType.CODE,),
     display_root: Path | None = None,
     previous: PreviousIndex | None = None,
-    show_progress: bool = False,
+    show_progress_bar: bool = False,
 ) -> tuple[BM25, SelectableBasicBackend, list[Chunk], dict[str, FileManifestEntry]]:
     """Create an index from a resolved directory, optionally reusing a previous index's unchanged files.
 
@@ -83,7 +83,7 @@ def create_index_from_path(
     :param content: Content types to index.
     :param display_root: If set, chunk file paths are stored relative to this root.
     :param previous: A previously built index to reuse unchanged files' chunks/embeddings/postings from.
-    :param show_progress: Show a progress bar on stderr while indexing.
+    :param show_progress_bar: Show a progress bar on stderr while indexing.
     :raises ValueError: if no items were found, no index can be created.
     :return: A BM25 index, semantic index, list of chunks, and file manifest.
     """
@@ -103,7 +103,9 @@ def create_index_from_path(
     skipped_large: list[str] = []
 
     files = list(walk_files(path, resolved_extensions))
-    for file_path in tqdm(files, desc="Indexing", unit="file", file=sys.stderr, leave=False, disable=not show_progress):
+    for file_path in tqdm(
+        files, desc="Indexing", unit="file", file=sys.stderr, leave=False, colour="green", disable=not show_progress_bar
+    ):
         language = detect_language(file_path)
         with contextlib.suppress(OSError):
             file_status = get_file_status(file_path, None)

--- a/src/semble/index/create.py
+++ b/src/semble/index/create.py
@@ -1,10 +1,12 @@
 import contextlib
 import logging
-from collections.abc import Callable, Sequence
+import sys
+from collections.abc import Sequence
 from pathlib import Path
 
 import numpy as np
 from model2vec.model import StaticModel
+from tqdm import tqdm
 from vicinity.backends.basic import BasicArgs
 
 from semble.chunking import chunk_source
@@ -72,7 +74,7 @@ def create_index_from_path(
     content: ContentType | Sequence[ContentType] = (ContentType.CODE,),
     display_root: Path | None = None,
     previous: PreviousIndex | None = None,
-    on_progress: Callable[[int, int], None] | None = None,
+    show_progress: bool = False,
 ) -> tuple[BM25, SelectableBasicBackend, list[Chunk], dict[str, FileManifestEntry]]:
     """Create an index from a resolved directory, optionally reusing a previous index's unchanged files.
 
@@ -81,7 +83,7 @@ def create_index_from_path(
     :param content: Content types to index.
     :param display_root: If set, chunk file paths are stored relative to this root.
     :param previous: A previously built index to reuse unchanged files' chunks/embeddings/postings from.
-    :param on_progress: Optional callback invoked as (files_done, files_total) after each candidate file.
+    :param show_progress: Show a progress bar on stderr while indexing.
     :raises ValueError: if no items were found, no index can be created.
     :return: A BM25 index, semantic index, list of chunks, and file manifest.
     """
@@ -100,12 +102,8 @@ def create_index_from_path(
 
     skipped_large: list[str] = []
 
-    candidate_files = list(walk_files(path, resolved_extensions))
-    total_files = len(candidate_files)
-    report_progress = on_progress or (lambda files_done, files_total: None)
-
-    for files_done, file_path in enumerate(candidate_files, start=1):
-        report_progress(files_done, total_files)
+    files = list(walk_files(path, resolved_extensions))
+    for file_path in tqdm(files, desc="Indexing", unit="file", file=sys.stderr, leave=False, disable=not show_progress):
         language = detect_language(file_path)
         with contextlib.suppress(OSError):
             file_status = get_file_status(file_path, None)

--- a/src/semble/index/index.py
+++ b/src/semble/index/index.py
@@ -144,7 +144,7 @@ class SembleIndex:
         :param content: Content types to index, e.g. ContentType.CODE or [ContentType.CODE, ContentType.DOCS].
         :param include_text_files: Deprecated. Pass a content sequence directly instead.
         :param model_path: Path to the model to use. If None, the default model will be used.
-        :param show_progress_bar: Show a progress bar on stderr while indexing.
+        :param show_progress_bar: Show a progress bar while indexing.
         :return: An indexed SembleIndex. Chunk file paths are relative to ``path``.
         :raises FileNotFoundError: If `path` does not exist.
         :raises NotADirectoryError: If `path` exists but is not a directory.
@@ -198,7 +198,7 @@ class SembleIndex:
         :param model_path: Path to the model to use. If None, the default model will be used.
         :param content: Content types to index, e.g. (ContentType.CODE,) or (ContentType.CODE, ContentType.DOCS).
         :param include_text_files: Deprecated. Pass content=(ContentType.CODE, ContentType.DOCS, ...) instead.
-        :param show_progress_bar: Show a progress bar on stderr while indexing.
+        :param show_progress_bar: Show a progress bar while indexing.
         :return: An indexed SembleIndex. Chunk file paths are repo-relative (e.g. ``src/foo.py``).
         :raises RuntimeError: If git is not on PATH, the clone fails, or times out.
         """

--- a/src/semble/index/index.py
+++ b/src/semble/index/index.py
@@ -136,7 +136,7 @@ class SembleIndex:
         content: ContentType | Sequence[ContentType] = _DEFAULT_CONTENT,
         include_text_files: bool | None = None,
         model_path: str | None = None,
-        show_progress: bool = False,
+        show_progress_bar: bool = False,
     ) -> SembleIndex:
         """Create and index a SembleIndex from a directory.
 
@@ -144,7 +144,7 @@ class SembleIndex:
         :param content: Content types to index, e.g. ContentType.CODE or [ContentType.CODE, ContentType.DOCS].
         :param include_text_files: Deprecated. Pass a content sequence directly instead.
         :param model_path: Path to the model to use. If None, the default model will be used.
-        :param show_progress: Show a progress bar on stderr while indexing.
+        :param show_progress_bar: Show a progress bar on stderr while indexing.
         :return: An indexed SembleIndex. Chunk file paths are relative to ``path``.
         :raises FileNotFoundError: If `path` does not exist.
         :raises NotADirectoryError: If `path` exists but is not a directory.
@@ -169,7 +169,7 @@ class SembleIndex:
             content=normalized,
             display_root=path,
             previous=previous,
-            show_progress=show_progress,
+            show_progress_bar=show_progress_bar,
         )
 
         return SembleIndex(
@@ -184,7 +184,7 @@ class SembleIndex:
         model_path: str | None = None,
         content: ContentType | Sequence[ContentType] = _DEFAULT_CONTENT,
         include_text_files: bool | None = None,
-        show_progress: bool = False,
+        show_progress_bar: bool = False,
     ) -> SembleIndex:
         """Clone a git repository and index it.
 
@@ -198,7 +198,7 @@ class SembleIndex:
         :param model_path: Path to the model to use. If None, the default model will be used.
         :param content: Content types to index, e.g. (ContentType.CODE,) or (ContentType.CODE, ContentType.DOCS).
         :param include_text_files: Deprecated. Pass content=(ContentType.CODE, ContentType.DOCS, ...) instead.
-        :param show_progress: Show a progress bar on stderr while indexing.
+        :param show_progress_bar: Show a progress bar on stderr while indexing.
         :return: An indexed SembleIndex. Chunk file paths are repo-relative (e.g. ``src/foo.py``).
         :raises RuntimeError: If git is not on PATH, the clone fails, or times out.
         """
@@ -229,7 +229,7 @@ class SembleIndex:
                 model=model,
                 content=normalized,
                 display_root=resolved_path,
-                show_progress=show_progress,
+                show_progress_bar=show_progress_bar,
             )
 
             return SembleIndex(

--- a/src/semble/index/index.py
+++ b/src/semble/index/index.py
@@ -5,7 +5,7 @@ import subprocess
 import tempfile
 import warnings
 from collections import defaultdict
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from datetime import datetime
 from pathlib import Path
 
@@ -136,6 +136,7 @@ class SembleIndex:
         content: ContentType | Sequence[ContentType] = _DEFAULT_CONTENT,
         include_text_files: bool | None = None,
         model_path: str | None = None,
+        on_progress: Callable[[int, int], None] | None = None,
     ) -> SembleIndex:
         """Create and index a SembleIndex from a directory.
 
@@ -143,6 +144,7 @@ class SembleIndex:
         :param content: Content types to index, e.g. ContentType.CODE or [ContentType.CODE, ContentType.DOCS].
         :param include_text_files: Deprecated. Pass a content sequence directly instead.
         :param model_path: Path to the model to use. If None, the default model will be used.
+        :param on_progress: Optional callback invoked as (files_done, files_total) while indexing.
         :return: An indexed SembleIndex. Chunk file paths are relative to ``path``.
         :raises FileNotFoundError: If `path` does not exist.
         :raises NotADirectoryError: If `path` exists but is not a directory.
@@ -167,6 +169,7 @@ class SembleIndex:
             content=normalized,
             display_root=path,
             previous=previous,
+            on_progress=on_progress,
         )
 
         return SembleIndex(
@@ -181,6 +184,7 @@ class SembleIndex:
         model_path: str | None = None,
         content: ContentType | Sequence[ContentType] = _DEFAULT_CONTENT,
         include_text_files: bool | None = None,
+        on_progress: Callable[[int, int], None] | None = None,
     ) -> SembleIndex:
         """Clone a git repository and index it.
 
@@ -194,6 +198,7 @@ class SembleIndex:
         :param model_path: Path to the model to use. If None, the default model will be used.
         :param content: Content types to index, e.g. (ContentType.CODE,) or (ContentType.CODE, ContentType.DOCS).
         :param include_text_files: Deprecated. Pass content=(ContentType.CODE, ContentType.DOCS, ...) instead.
+        :param on_progress: Optional callback invoked as (files_done, files_total) while indexing.
         :return: An indexed SembleIndex. Chunk file paths are repo-relative (e.g. ``src/foo.py``).
         :raises RuntimeError: If git is not on PATH, the clone fails, or times out.
         """
@@ -224,6 +229,7 @@ class SembleIndex:
                 model=model,
                 content=normalized,
                 display_root=resolved_path,
+                on_progress=on_progress,
             )
 
             return SembleIndex(

--- a/src/semble/index/index.py
+++ b/src/semble/index/index.py
@@ -5,7 +5,7 @@ import subprocess
 import tempfile
 import warnings
 from collections import defaultdict
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from datetime import datetime
 from pathlib import Path
 
@@ -136,7 +136,7 @@ class SembleIndex:
         content: ContentType | Sequence[ContentType] = _DEFAULT_CONTENT,
         include_text_files: bool | None = None,
         model_path: str | None = None,
-        on_progress: Callable[[int, int], None] | None = None,
+        show_progress: bool = False,
     ) -> SembleIndex:
         """Create and index a SembleIndex from a directory.
 
@@ -144,7 +144,7 @@ class SembleIndex:
         :param content: Content types to index, e.g. ContentType.CODE or [ContentType.CODE, ContentType.DOCS].
         :param include_text_files: Deprecated. Pass a content sequence directly instead.
         :param model_path: Path to the model to use. If None, the default model will be used.
-        :param on_progress: Optional callback invoked as (files_done, files_total) while indexing.
+        :param show_progress: Show a progress bar on stderr while indexing.
         :return: An indexed SembleIndex. Chunk file paths are relative to ``path``.
         :raises FileNotFoundError: If `path` does not exist.
         :raises NotADirectoryError: If `path` exists but is not a directory.
@@ -169,7 +169,7 @@ class SembleIndex:
             content=normalized,
             display_root=path,
             previous=previous,
-            on_progress=on_progress,
+            show_progress=show_progress,
         )
 
         return SembleIndex(
@@ -184,7 +184,7 @@ class SembleIndex:
         model_path: str | None = None,
         content: ContentType | Sequence[ContentType] = _DEFAULT_CONTENT,
         include_text_files: bool | None = None,
-        on_progress: Callable[[int, int], None] | None = None,
+        show_progress: bool = False,
     ) -> SembleIndex:
         """Clone a git repository and index it.
 
@@ -198,7 +198,7 @@ class SembleIndex:
         :param model_path: Path to the model to use. If None, the default model will be used.
         :param content: Content types to index, e.g. (ContentType.CODE,) or (ContentType.CODE, ContentType.DOCS).
         :param include_text_files: Deprecated. Pass content=(ContentType.CODE, ContentType.DOCS, ...) instead.
-        :param on_progress: Optional callback invoked as (files_done, files_total) while indexing.
+        :param show_progress: Show a progress bar on stderr while indexing.
         :return: An indexed SembleIndex. Chunk file paths are repo-relative (e.g. ``src/foo.py``).
         :raises RuntimeError: If git is not on PATH, the clone fails, or times out.
         """
@@ -229,7 +229,7 @@ class SembleIndex:
                 model=model,
                 content=normalized,
                 display_root=resolved_path,
-                on_progress=on_progress,
+                show_progress=show_progress,
             )
 
             return SembleIndex(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,6 +34,8 @@ def test_main_calls_asyncio_run(argv: list[str], monkeypatch: pytest.MonkeyPatch
     [
         (["semble", "search", "query text", "/some/path"], ["query text", "0.9"]),
         (["semble", "search", "nothing", "/some/path", "--top-k", "3"], ["No results found"]),
+        (["semble", "search", "query text", "/some/path", "--pretty"], ["src/foo.py:1-1\n\ndef foo(): pass"]),
+        (["semble", "search", "nothing", "/some/path", "--pretty"], ["No results found."]),
     ],
 )
 def test_cli_search(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -61,6 +61,7 @@ def test_cli_search(
     ("scenario", "expected_stdout", "expected_stderr", "expected_exit_code"),
     [
         ("with_results", ["src/bar.py", "0.8"], None, None),
+        ("pretty", ["src/bar.py:1-1\n\nclass Bar: pass"], None, None),
         ("no_results", ["No related chunks found"], None, None),
         ("unknown_chunk", [], "No chunk found", 1),
     ],
@@ -77,9 +78,11 @@ def test_cli_find_related(
     chunk = make_chunk("class Bar: pass", "src/bar.py")
     fake_index = MagicMock()
     fake_index.chunks = [] if scenario == "unknown_chunk" else [chunk]
-    fake_index.find_related.return_value = [SearchResult(chunk=chunk, score=0.8)] if scenario == "with_results" else []
+    has_results = scenario in ("with_results", "pretty")
+    fake_index.find_related.return_value = [SearchResult(chunk=chunk, score=0.8)] if has_results else []
     file_path = "unknown.py" if scenario == "unknown_chunk" else "src/bar.py"
-    monkeypatch.setattr(sys, "argv", ["semble", "find-related", file_path, "1", "/some/path"])
+    argv = ["semble", "find-related", file_path, "1", "/some/path"] + (["--pretty"] if scenario == "pretty" else [])
+    monkeypatch.setattr(sys, "argv", argv)
     with patch("semble.cli.SembleIndex.from_path", return_value=fake_index):
         if expected_exit_code is None:
             _cli_main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,8 +34,8 @@ def test_main_calls_asyncio_run(argv: list[str], monkeypatch: pytest.MonkeyPatch
     [
         (["semble", "search", "query text", "/some/path"], ["query text", "0.9"]),
         (["semble", "search", "nothing", "/some/path", "--top-k", "3"], ["No results found"]),
-        (["semble", "search", "query text", "/some/path", "--pretty"], ["src/foo.py:1-1\n\ndef foo(): pass"]),
-        (["semble", "search", "nothing", "/some/path", "--pretty"], ["No results found."]),
+        (["semble", "search", "query text", "/some/path", "--format", "text"], ["src/foo.py:1-1\n\ndef foo(): pass"]),
+        (["semble", "search", "nothing", "/some/path", "--format", "text"], ["No results found."]),
     ],
 )
 def test_cli_search(
@@ -61,7 +61,7 @@ def test_cli_search(
     ("scenario", "expected_stdout", "expected_stderr", "expected_exit_code"),
     [
         ("with_results", ["src/bar.py", "0.8"], None, None),
-        ("pretty", ["src/bar.py:1-1\n\nclass Bar: pass"], None, None),
+        ("text", ["src/bar.py:1-1\n\nclass Bar: pass"], None, None),
         ("no_results", ["No related chunks found"], None, None),
         ("unknown_chunk", [], "No chunk found", 1),
     ],
@@ -78,10 +78,12 @@ def test_cli_find_related(
     chunk = make_chunk("class Bar: pass", "src/bar.py")
     fake_index = MagicMock()
     fake_index.chunks = [] if scenario == "unknown_chunk" else [chunk]
-    has_results = scenario in ("with_results", "pretty")
+    has_results = scenario in ("with_results", "text")
     fake_index.find_related.return_value = [SearchResult(chunk=chunk, score=0.8)] if has_results else []
     file_path = "unknown.py" if scenario == "unknown_chunk" else "src/bar.py"
-    argv = ["semble", "find-related", file_path, "1", "/some/path"] + (["--pretty"] if scenario == "pretty" else [])
+    argv = ["semble", "find-related", file_path, "1", "/some/path"] + (
+        ["--format", "text"] if scenario == "text" else []
+    )
     monkeypatch.setattr(sys, "argv", argv)
     with patch("semble.cli.SembleIndex.from_path", return_value=fake_index):
         if expected_exit_code is None:

--- a/uv.lock
+++ b/uv.lock
@@ -3140,6 +3140,7 @@ dependencies = [
     { name = "pathspec" },
     { name = "questionary" },
     { name = "semble-grammars" },
+    { name = "tqdm" },
     { name = "vicinity" },
 ]
 
@@ -3186,6 +3187,7 @@ requires-dist = [
     { name = "semble-grammars", specifier = ">=0.1.2" },
     { name = "sentence-transformers", marker = "extra == 'benchmark'", specifier = ">=3.0" },
     { name = "tiktoken", marker = "extra == 'benchmark'", specifier = ">=0.7" },
+    { name = "tqdm", specifier = ">=4.60" },
     { name = "vicinity", specifier = ">=0.4.4" },
 ]
 provides-extras = ["mcp", "benchmark", "dev"]


### PR DESCRIPTION
This PR adds a progressbar to the CLI for indexing to make it more visible how long indexing will take. The progressbar disappears after indexing finishes (we could keep it though? Idk). Also added a `--format` argument to make the CLI output nice to read (mainly for demo purposes for a cool followup), which can be `json` (default) or `text`. We already had tqdm as a transitive dep, now it's just added since we import it directly.

Screenshot:
<img width="1200" height="700" alt="image" src="https://github.com/user-attachments/assets/215c5374-bab4-4be3-9830-f712f13b91e4" />
